### PR TITLE
Nobody uses simplejson

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -34,7 +34,6 @@ mailinglogger = 3.7.0
 python-dateutil = 1.5
 python-openid = 2.2.5
 repoze.xmliter = 0.5
-simplejson = 2.5.0
 WebOb = 1.0.8
 
 # Plone release


### PR DESCRIPTION
It is only imported in Products.TinyMCE as a fallback if json is not found, which is hard to achieve in Python 2.6 upwards.

Or is there any good reason not to remove it?
