### PR TITLE
Remove duplicate entry: plone.rfc822

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -210,7 +210,6 @@ plone.formwidget.contenttree          = 1.0.6
 plone.formwidget.namedfile            = 1.0.3
 plone.mocktestcase                    = 1.0b3
 plone.namedfile                       = 1.0.6
-plone.rfc822                          = 1.0
 plone.schemaeditor                    = 1.2.1
 plone.synchronize                     = 1.0.1
 rwproperty                            = 1.0


### PR DESCRIPTION
buildouts don't break, but playing with pip and its requirements.txt format and dependencies showed that plone.rfc822 is added twice (with the same version) on our own versions.cfg.

As is within a section called ecosystem, I don't know if that comes from somewhere else, and thus the source of the duplication will still hit us again...
