### PR TITLE
Pin development eggs versions.

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -132,6 +132,15 @@ test-eggs =
     z3c.autoinclude
     zope.globalrequest
 
+[versions]
+# egg versions that are not part of the release, but should still be pinned
+# so our development builds are repeatable
+collective.recipe.sphinxbuilder = 0.7.1
+pep8 = 1.4.1
+plone.recipe.command = 1.1
+selenium = 2.29.0
+unittest-jshint = 1.0
+
 [test]
 recipe = zc.recipe.testrunner
 eggs = ${buildout:test-eggs}


### PR DESCRIPTION
Some eggs versions are not pinned in versions.cfg, because those eggs are
not part of the release -- they are used for development only. However we
should still pin them to keep our development builds repeatable.
