### PR TITLE
Pin up pep8 for compatibility with newest flake8.

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -136,7 +136,7 @@ test-eggs =
 # egg versions that are not part of the release, but should still be pinned
 # so our development builds are repeatable
 collective.recipe.sphinxbuilder = 0.7.1
-pep8 = 1.4.1
+pep8 = 1.4.3
 plone.recipe.command = 1.1
 selenium = 2.29.0
 unittest-jshint = 1.0


### PR DESCRIPTION
Flake8 2.0 requires at least pep8 = 1.4.3.

@tisto This is required for running the translation report job on jenkins - the jenkins-code-analysis.cfg is not running at the moment.

The `./bin/jenkins-code-analysis-flake8` has some errors at the moment, but it has it with Flake8 1.x also so I did not investigate further. The error is:

```
-n Analyse packages/plonetheme/sunburst/
xargs: illegal option -- r
usage: xargs [-0opt] [-E eofstr] [-I replstr [-R replacements]] [-J replstr]
             [-L number] [-n number [-x]] [-P maxprocs] [-s size]
             [utility [argument ...]]
```
