### PR TITLE
Update zodb remote

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -25,7 +25,7 @@ zopegit_push = git@github.com:zopefoundation
 
 [sources]
 Zope2                               = git ${remotes:zopegit}/Zope.git pushurl=${remotes:zopegit_push}/Zope.git branch=2.13
-ZODB3                               = svn ${remotes:zope}/ZODB/branches/3.10
+ZODB3                               = git ${remotes:zopegit}/ZODB.git pushurl=${remotes:zopegit_push}/ZODB.git branch=3.10
 Plone                               = git ${remotes:plone}/Plone.git pushurl=${remotes:plone_push}/Plone.git branch=master
 archetypes.querywidget              = git ${remotes:plone}/archetypes.querywidget.git pushurl=${remotes:plone_push}/archetypes.querywidget.git branch=master
 archetypes.referencebrowserwidget   = git ${remotes:plone}/archetypes.referencebrowserwidget.git pushurl=${remotes:plone_push}/archetypes.referencebrowserwidget.git branch=master


### PR DESCRIPTION
ZODB seems to have been moved to GitHub: https://github.com/zopefoundation/ZODB

Note that jenkins jobs will fail (and for that matter all buildout runs) if they have a previous version of ZODB on src/

Seems that mr.developer is not capable of changing a repository from svn to git, so a removal of that folder _before_ running bin/buildout is needed.
