### PR TITLE
Add plone.app.iterate support for Dexterity to core via p.a.stagingbehavior

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -13,6 +13,7 @@ auto-checkout =
     plone.app.layout
     plone.app.locales
     plone.app.relationfield
+    plone.app.stagingbehavior
     plone.app.testing
     plone.app.upgrade
     plone.app.versioningbehavior

--- a/sources.cfg
+++ b/sources.cfg
@@ -76,6 +76,7 @@ plone.app.registry                  = git ${remotes:plone}/plone.app.registry.gi
 plone.app.relationfield             = git ${remotes:plone}/plone.app.relationfield.git pushurl=${remotes:plone_push}/plone.app.relationfield.git branch=master
 plone.app.robotframework            = git ${remotes:plone}/plone.app.robotframework.git pushurl=${remotes:plone_push}/plone.app.robotframework.git branch=master
 plone.app.search                    = git ${remotes:plone}/plone.app.search.git pushurl=${remotes:plone_push}/plone.app.search.git branch=master
+plone.app.stagingbehavior        = git ${remotes:plone}/plone.app.stagingbehavior.git pushurl=${remotes:plone_push}/plone.app.stagingbehavior.git branch=master
 plone.app.testing                   = git ${remotes:plone}/plone.app.testing.git pushurl=${remotes:plone_push}/plone.app.testing.git branch=master
 plone.app.textfield                 = git ${remotes:plone}/plone.app.textfield.git pushurl=${remotes:plone_push}/plone.app.textfield.git branch=master
 plone.app.theming                   = git ${remotes:plone}/plone.app.theming.git pushurl=${remotes:plone_push}/plone.app.theming.git branch=master

--- a/tests.cfg
+++ b/tests.cfg
@@ -76,6 +76,7 @@ test-eggs =
     plone.app.redirector
     plone.app.registry
     plone.app.search [test]
+    plone.app.stagingbehavior [test]
     plone.app.testing [test]
     plone.app.textfield [tests]
     plone.app.theming [test]
@@ -431,6 +432,7 @@ exclude =
     Products.TinyMCE
     plone.app.imaging
     plone.app.locales
+    plone.app.stagingbehavior
     plone.app.versioningbehavior
     plone.formwidget.datetime
     plone.reload


### PR DESCRIPTION
Since plone.app.iterate is in core, and plone.app.contenttypes is the
new default, we should support plone.app.iterate for Dexterity in core.
Unfortunately. the plone.app.stagingbehavior tests don't currently pass
in coredev so I'm just going to put this in a pull request.
