### PR TITLE
Remove buildout.dumppickedversions extension

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -28,7 +28,6 @@ find-links += http://dist.plone.org/thirdparty/
 
 extensions =
     mr.developer
-    buildout.dumppickedversions
 
 versions = versions
 


### PR DESCRIPTION
With a modern buildout this gives me the Error: Buildout now includes 'buildout-versions' (and part of the older 'buildout.dumppickedversions').

I think it's best to remove the buildout.dumppickedversions extension. 
