### PR TITLE
Use zest.releaser 4.0.

### DIFF
--- a/release.cfg
+++ b/release.cfg
@@ -1,16 +1,10 @@
 # Run: bin/manage report --interactive
 [buildout]
 extends = buildout.cfg
-parts += release
 auto-checkout += plone.releaser
-eggs += plone.releaser 
-        pdbpp
-        zest.pocompile
-        Products.PrintingMailhost
-
-[release]
-recipe = zc.recipe.egg
-eggs =  plone.releaser
+eggs +=
+    pdbpp
+    Products.PrintingMailhost
 
 [sources]
 plone.releaser = git git://github.com/plone/plone.releaser.git pushurl=git@github.com:plone/plone.releaser.git
@@ -24,15 +18,20 @@ exclude +=
     keyring
 
 [releaser]
-eggs += plone.releaser
-        check-manifest
+dependent-scripts = true
+eggs +=
+    plone.releaser
+    zest.releaser[recommended]
 
 [versions]
 Products.PrintingMailHost = 0.8
+colorama = 0.3.3
 fancycompleter = 0.4
 pdbpp = 0.8.2
+pkginfo = 1.2.1
 pyrepl = 0.8.4
-
-# Required by:
-# pdbpp==0.8.2
+pyroma = 1.8.1
+requests = 2.7.0
+twine = 1.5.0
+wheel = 0.24.0
 wmctrl = 0.1

--- a/tests.cfg
+++ b/tests.cfg
@@ -181,7 +181,7 @@ wadllib = 1.3.2
 watchdog = 0.8.3
 z3c.recipe.scripts = 1.0.1
 zest.pocompile = 1.4
-zest.releaser = 3.56
+zest.releaser = 4.0
 
 
 [environment]


### PR DESCRIPTION
I have released zest.releaser 4.0. Some nice new features that I will blog about soon. We should use it in coredev.

This updates and cleans up `release.cfg`.

@esteele @tisto @gforcada please have a look and try it out.
