### PR TITLE
Test plone app intid on Plone 4.3 branch

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -3,6 +3,7 @@ always-checkout = force
 auto-checkout =
     Products.CMFPlone
     plone.app.locales
+    plone.app.intid
 # Test fixes only (or otherwise not-gonna-release changes)
 #    collective.xmltestreport
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -93,7 +93,7 @@ plone.app.folder                    = git ${remotes:plone}/plone.app.folder.git 
 plone.app.form                      = git ${remotes:plone}/plone.app.form.git pushurl=${remotes:plone_push}/plone.app.form.git branch=2.2.x
 plone.app.i18n                      = git ${remotes:plone}/plone.app.i18n.git pushurl=${remotes:plone_push}/plone.app.i18n.git branch=2.x
 plone.app.imaging                   = git ${remotes:plone}/plone.app.imaging.git pushurl=${remotes:plone_push}/plone.app.imaging.git branch=1.0.x
-plone.app.intid                     = git ${remotes:plone}/plone.app.intid.git pushurl=${remotes:plone_push}/plone.app.intid.git
+plone.app.intid                     = git ${remotes:plone}/plone.app.intid.git pushurl=${remotes:plone_push}/plone.app.intid.git branch=1.0.x
 plone.app.iterate                   = git ${remotes:plone}/plone.app.iterate.git pushurl=${remotes:plone_push}/plone.app.iterate.git branch=2.1.x
 plone.app.jquery                    = git ${remotes:plone}/plone.app.jquery.git pushurl=${remotes:plone_push}/plone.app.jquery.git branch=1.7
 plone.app.jquerytools               = git ${remotes:plone}/plone.app.jquerytools.git pushurl=${remotes:plone_push}/plone.app.jquerytools.git branch=master

--- a/tests.cfg
+++ b/tests.cfg
@@ -62,6 +62,7 @@ test-eggs =
     plone.app.form
     plone.app.i18n
     plone.app.imaging [test]
+    plone.app.intid [test]
     plone.app.iterate
     plone.app.jquery [test]
     plone.app.jquerytools [test]
@@ -230,6 +231,7 @@ Plone =
     plone.app.customerize
     plone.app.form
     plone.app.i18n
+    plone.app.intid
     plone.app.layout
     plone.app.redirector
     plone.app.vocabularies


### PR DESCRIPTION
I noticed that plone.app.intid is not tested on 4.3 coredev. And 4.3 is using the master branch, which got some changes recently. The changes may be safe, but one of them at least gives a test failure on 4.3. See https://github.com/plone/plone.app.intid/pull/3

So: we should the package. Or was there a specific reason that we are not doing this yet?
