### PR TITLE
Add script to see how many circular dependencies exist

### DIFF
--- a/circular_deps.py
+++ b/circular_deps.py
@@ -1,0 +1,11 @@
+import networkx as nx
+
+dep_graph = nx.read_dot('total_no_extras.dot')
+
+edges = set()
+for dep in dep_graph.edges_iter():
+    sorted_dep = tuple(sorted(dep))
+    if sorted_dep not in edges:
+        edges.add(sorted_dep)
+    else:
+        print('Circular dependency between {0}'.format(dep))

--- a/jenkins-package-dependencies.cfg
+++ b/jenkins-package-dependencies.cfg
@@ -30,6 +30,8 @@ parts +=
     jenkins-package-dependencies-formlib-imports
     jenkins-package-dependencies-grok
     jenkins-package-dependencies-grok-imports
+    depspy
+    circular-deps
 
 auto-checkout = *
 
@@ -38,34 +40,156 @@ versions = versions
 [sources]
 Products.MailHost = git ${remotes:zope}/Products.MailHost.git pushurl=${remotes:zope_push}/Products.MailHost.git rev=c531ac4c070e6b65a2424ddd42b0ac7281f385f9
 
-[eggdeps]
+[depspy]
 recipe = zc.recipe.egg
-eggs = 
-    ${instance:eggs}
-    ${test:eggs}
-    tl.eggdeps
+eggs =
+    networkx
+    pydot2
+interpreter = depspy
+scripts = depspy
 
-[jenkins-package-dependencies]
+[circular-deps]
 recipe = collective.recipe.template
 input = inline:
-  #!/bin/sh
-  ${buildout:directory}/bin/eggdeps --no-extras -d -i apparmor -i apt-xapian-index -i acquisition -i argparse -i chardet -i command-not-found -i defer -i distribute -i setuptools -i gnupginterface -i iotop -i language-selector -i mercurial -i pep8 -i pil -i pycurl -i pyflakes -i pymetrics -i python -i python-apt -i python-debian -i python-ldap -i tl.eggdeps -i ufw -i unattended-upgrades -i wsgiref > package-dependencies.dot
+    #!/bin/sh
+    bin/eggdeps -xd > total_no_extras.dot
+    bin/depspy circular_deps.py
+output = bin/circular_deps
+mode = 755
+
+[eggdeps]
+recipe = zc.recipe.egg
+eggs =
+    ${instance:eggs}
+    ${test:eggs}
+    tt.eggdeps
+
+
+[deps]
+data =
+    -I archetypes.*
+    -I collective.*
+    -I five.*
+    -I grok.*
+    -I python-*
+    -I repoze.*
+    -I robot*
+    -I z3c.*
+    -I zc.*
+    -I zope.*
+    -i accesscontrol
+    -i acquisition
+    -i argh
+    -i argparse
+    -i babel
+    -i chameleon
+    -i cssmin
+    -i cssselect
+    -i datetime
+    -i decorator
+    -i diazo
+    -i documenttemplate
+    -i docutils
+    -i extensionclass
+    -i feedparser
+    -i formencode
+    -i future
+    -i icalendar
+    -i initgroups
+    -i lxml
+    -i mailinglogger
+    -i manuel
+    -i markdown
+    -i martian
+    -i mechanize
+    -i missing
+    -i mock
+    -i mocker
+    -i multimapping
+    -i pathtools
+    -i persistence
+    -i pillow
+    -i pip
+    -i plone.app.openid
+    -i plone.app.robotframework
+    -i plone.app.testing
+    -i plone.app.upgrade
+    -i plone.mocktestcase
+    -i plone.openid
+    -i plone.reload
+    -i plone.testing
+    -i ply
+    -i products.archetypes
+    -i products.externalmethod
+    -i products.genericsetup
+    -i products.i18ntestcase
+    -i products.mailhost
+    -i products.mimetools
+    -i products.ofsp
+    -i products.securemailhost
+    -i products.standardcachemanagers
+    -i products.zsqlmethods
+    -i pygments
+    -i python
+    -i pytz
+    -i pyyaml
+    -i record
+    -i roman
+    -i selenium
+    -i setuptools
+    -i simplejson
+    -i six
+    -i slimit
+    -i sourcecodegen
+    -i tempstorage
+    -i transaction
+    -i tt.eggdeps
+    -i unidecode
+    -i unittest2
+    -i watchdog
+    -i webob
+    -i wsgi-intercept
+    -i wsgiref
+    -i zconfig
+    -i zdaemon
+    -i zexceptions
+    -i zlog
+    -i zodb3
+
+
+[jenkins-package-dependencies]
+# to play around with the dot information install the following distributions:
+# pip install networkx dot_parser pydot2
+recipe = collective.recipe.template
+input = inline:
+    #!/bin/sh
+    ARGS=`echo "${deps:data}" | paste -s -d" "`
+    ${buildout:bin-directory}/eggdeps -d --no-extras $ARGS > deps.dot
+    sed -i 's/plone\.app\./p\.a\./g' deps.dot
+    sed -i 's/plone\./p\./g' deps.dot
+    sed -i 's/products\./P\./g' deps.dot
 output = ${buildout:directory}/bin/jenkins-package-dependencies
 mode = 755
+
 
 [jenkins-package-dependencies-with-tests]
 recipe = collective.recipe.template
 input = inline:
-  #!/bin/sh
-  ${buildout:directory}/bin/eggdeps -i apparmor -d -i apt-xapian-index -i acquisition -i argparse -i chardet -i command-not-found -i defer -i distribute -i setuptools -i gnupginterface -i iotop -i language-selector -i mercurial -i pep8 -i pil -i pycurl -i pyflakes -i pymetrics -i python -i python-apt -i python-debian -i python-ldap -i tl.eggdeps -i ufw -i unattended-upgrades -i wsgiref > package-dependencies-with-tests.dot
+    #!/bin/sh
+    ARGS=`echo "${deps:data}" | paste -s -d" "`
+    ${buildout:bin-directory}/eggdeps -d $ARGS > package-dependencies-with-tests.dot
+    sed -i 's/plone\.app\./p\.a\./g' package-dependencies-with-tests.dot
+    sed -i 's/plone\./p\./g' package-dependencies-with-tests.dot
+    sed -i 's/products\./P\./g' package-dependencies-with-tests.dot
 output = ${buildout:directory}/bin/jenkins-package-dependencies-with-tests
 mode = 755
 
 [jenkins-package-dependencies-text]
 recipe = collective.recipe.template
 input = inline:
-  #!/bin/sh
-  ${buildout:directory}/bin/eggdeps -i apparmor -i apt-xapian-index -i acquisition -i argparse -i chardet -i command-not-found -i defer -i distribute -i setuptools -i gnupginterface -i iotop -i language-selector -i mercurial -i pep8 -i pil -i pycurl -i pyflakes -i pymetrics -i python -i python-apt -i python-debian -i python-ldap -i tl.eggdeps -i ufw -i unattended-upgrades -i wsgiref > package-dependencies.txt
+    #!/bin/sh
+    ARGS=`echo "${deps:data}" | paste -s -d" "`
+    ${buildout:bin-directory}/eggdeps $ARGS > package-dependencies.txt
 output = ${buildout:directory}/bin/jenkins-package-dependencies-text
 mode = 755
 


### PR DESCRIPTION
Just run:

```
bin/buildout -c jenkins-package-dependencies.cfg
bin/circular_deps
```

Which outputs:

```
Circular dependency between ('products.externalmethod', 'zope2')
Circular dependency between ('products.mailhost', 'zope2')
Circular dependency between ('plone.app.workflow', 'products.cmfplone')
Circular dependency between ('plone.app.dexterity', 'products.cmfplone')
Circular dependency between ('plone.app.controlpanel', 'products.cmfplone')
Circular dependency between ('plone.app.portlets', 'products.cmfplone')
Circular dependency between ('plone.app.theming', 'products.cmfplone')
Circular dependency between ('plone.app.widgets', 'products.cmfplone')
Circular dependency between ('plone.app.widgets', 'plone.app.z3cform')
Circular dependency between ('plone.app.registry', 'products.cmfplone')
Circular dependency between ('plone.app.contentrules', 'products.cmfplone')
Circular dependency between ('plone.app.users', 'products.cmfplone')
Circular dependency between ('plone.app.contenttypes', 'products.cmfplone')
Circular dependency between ('plone.app.discussion', 'products.cmfplone')
Circular dependency between ('products.standardcachemanagers', 'zope2')
Circular dependency between ('products.pythonscripts', 'zope2')
Circular dependency between ('products.zcatalog', 'zope2')
Circular dependency between ('plone.app.multilingual', 'products.cmfplone')
Circular dependency between ('plone.app.multilingual', 'archetypes.multilingual')
Circular dependency between ('plone.app.content', 'products.cmfplone')
Circular dependency between ('products.ofsp', 'zope2')
Circular dependency between ('plone.app.contentmenu', 'products.cmfplone')
Circular dependency between ('products.btreefolder2', 'zope2')
Circular dependency between ('plone.app.layout', 'products.cmfplone')
Circular dependency between ('plone.app.layout', 'plone.app.portlets')
Circular dependency between ('products.passwordresettool', 'products.cmfplone')
Circular dependency between ('plone.app.querystring', 'plone.app.vocabularies')
Circular dependency between ('products.zctextindex', 'zope2')
```

**NOTE:** it's probably _NOT_ worth merging this, but mostly as a way to see the tip of the iceberg regarding our forest of dependencies as (@jensens dubbed it) as there are a lot of dependencies not being declared at all on distributions setup.py's.

I pushed quite a few changes on `z3c.dependencychecker` so that it detects most of the dependencies.

Next steps should be to create a reporter for all distributions about their missing dependencies, so they can be fixed one at a time and then enjoy how the forest grows and grows :popcorn:
