### PR TITLE
Update pin for collective.z3cform.datagridfield and pin zc.queue to 1.3

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -237,7 +237,7 @@ zope.schema                           = 4.2.2
 # Ecosystem (not officially part of core)
 collective.elephantvocabulary         = 0.2.5
 collective.js.jqueryui                = 1.10.3
-collective.z3cform.datagridfield      = 0.11
+collective.z3cform.datagridfield      = 1.1
 collective.z3cform.datagridfield-demo = 0.5
 collective.z3cform.datetimewidget     = 1.2.5
 five.grok                             = 1.3.2
@@ -264,6 +264,7 @@ plone.formwidget.contenttree          = 1.0.11
 plone.mocktestcase                    = 1.0b3
 z3c.objpath                           = 1.1
 z3c.relationfield                     = 0.7
+zc.queue                              = 1.3
 zc.relation                           = 1.0
 
 plone.app.multilingual                = 3.0.11


### PR DESCRIPTION
collective.z3cform.datagridfield 0.11 is really old
zc.queue > 1.3 triggers ZODB4 and friends resulting in broken buildouts
