### PR TITLE
zc.buildout 2.5.0, setuptools 18.5

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -31,11 +31,11 @@ plone.recipe.alltests = 1.5
 plone.recipe.zeoserver = 1.2.8
 plone.recipe.zope2instance = 4.2.18
 plone.releaser = 1.3
-setuptools = 18.4
+setuptools = 18.5
 z3c.coverage = 1.2.0
 z3c.ptcompat = 1.0.1
 z3c.template = 1.4.1
-zc.buildout = 2.4.5
+zc.buildout = 2.5.0
 
 # Robot Testing
 plone.app.robotframework = 0.9.12


### PR DESCRIPTION
Buildout 2.5.0 has much nicer version conflict reporting:
http://reinout.vanrees.org/weblog/2015/11/16/buildout-nicer-version-conflicts.html
