### PR TITLE
fix links and naming

### DIFF
--- a/docs/agreement.rst
+++ b/docs/agreement.rst
@@ -28,7 +28,7 @@ We do ask that before requesting core access you familiarize yourself a little w
   Technically,
   in order for us to accept your patch you must sign the contributors agreement.
   If you want to contribute fixes,
-  please just sign the agreement and go through the standard github pull request process described below until you feel comfortable to bypass review.
+  please just sign the agreement and go through the standard GitHub pull request process described below until you feel comfortable to bypass review.
   If the ticket is trivial,
   or you're fixing documentation,
   you do not need to sign a contributor's agreement.

--- a/docs/continous-integration.rst
+++ b/docs/continous-integration.rst
@@ -43,7 +43,7 @@ or just revert the commit in order to be able to continue to work.
 Following this practice ensures the build stays green and other developers can continue to work without breaking the first rule.
 
 There might be changes that have been checked in before your last update from the version control that might lead to a build failure in Jenkins in combination with your changes.
-Therefore it is essential that you check out (:command:`git pull`) and run the tests again before you push your changes to github.
+Therefore it is essential that you check out (:command:`git pull`) and run the tests again before you push your changes to GitHub.
 
 Furthermore,
 a common source of errors on check-in is to forget to add some files to the repository.

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -15,7 +15,7 @@ others are included:
 * :doc:`/adapt-and-extend/theming/index`
 * :doc:`/develop/index`
 
-The documentation is hosted on `github <https://github.com/plone/documentation>`_ and information how to contribute can be found at :doc:`/about/contributing`.
+The documentation is hosted on `GitHub <https://github.com/plone/documentation>`_ and information how to contribute can be found at :doc:`/about/contributing`.
 
 Documenting a package
 =====================
@@ -29,7 +29,7 @@ your package should include the following forms of documentation:
   :file:`README.rst`
     The readme is the first entry point for most people to your package.
     It will be included on the PyPI page for your egg,
-    and on the front page of its github repository.
+    and on the front page of its GitHub repository.
     It should be formatted using `reStructuredText (reST) <http://docutils.sourceforge.net/rst.html>`_ in order to get formatted properly by those systems.
 
     :file:`README.rst` should include:
@@ -64,7 +64,7 @@ your package should include the following forms of documentation:
 
     If your project is moderately complex,
     you may want to set up your documentation with multiple pages.
-    The best way to do this is to add Sphinx to your project and host your docs on readthedocs.org so that it rebuilds the documentation whenever you push to github.
+    The best way to do this is to add Sphinx to your project and host your docs on readthedocs.org so that it rebuilds the documentation whenever you push to GitHub.
     If you do this,
     your :file:`README.rst` must link off site to the documentation.
 

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -10,12 +10,12 @@ Documentation of Plone
 The comprehensive resource for Plone documentation is http://docs.plone.org/. The following sections among 
 others are included: 
 
-* :doc:`/working-with-content/index`
-* :doc:`/manage/installing/index`
-* :doc:`/adapt-and-extend/theming/index`
-* :doc:`/develop/index`
+* :doc:`User Manual </working-with-content/index>`
+* :doc:`Installing Plone </manage/installing/index>`
+* :doc:`Theme Reference </adapt-and-extend/theming/index>`
+* :doc:`Developer Manual </develop/index>`
 
-The documentation is hosted on `GitHub <https://github.com/plone/documentation>`_ and information how to contribute can be found at :doc:`/about/contributing`.
+The documentation is hosted on `GitHub <https://github.com/plone/documentation>`_ and information how to contribute can be found at :doc:`Contributing to the documentation </about/contributing>`.
 
 Documenting a package
 =====================

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -10,13 +10,12 @@ Documentation of Plone
 The comprehensive resource for Plone documentation is http://docs.plone.org/. The following sections among 
 others are included: 
 
-* `User Manual <http://docs.plone.org/working-with-content/index.html>`_
-* `Installing Plone <http://docs.plone.org/manage/installing/index.html>`_
-* `Theme Reference <http://docs.plone.org/adapt-and-extend/theming/index.html>`_
-* `Developer Manual <http://docs.plone.org/develop/index.html>`_
+* :doc:`/working-with-content/index`
+* :doc:`/manage/installing/index`
+* :doc:`/adapt-and-extend/theming/index`
+* :doc:`/develop/index`
 
-The documentation is hosted on `github <https://github.com/plone/documentation>`_ and information how to 
-contribute can be found `here <http://docs.plone.org/about/contributing.html>`_
+The documentation is hosted on `github <https://github.com/plone/documentation>`_ and information how to contribute can be found at :doc:`/about/contributing`.
 
 Documenting a package
 =====================

--- a/docs/git.rst
+++ b/docs/git.rst
@@ -414,8 +414,7 @@ Following this advice will:
 Making commits
 --------------
 
-For commit messages see:
-`plone API guidelines <http://docs.plone.org/develop/plone.api/docs/contribute/conventions.html#git-commit-message-style>`_.
+For commit messages see: :ref:`git_commit_message_style_guide`.
 
 
 Adding references to issues

--- a/docs/guidelines.rst
+++ b/docs/guidelines.rst
@@ -6,7 +6,7 @@
 Guidelines for contributing to Plone Core
 =========================================
 
-You probably came here by clicking one of the 'guidelines for contributing' links on github.
+You probably came here by clicking one of the 'guidelines for contributing' links on GitHub.
 So you probably have an issue to report or you want to create a pull request.
 Thanks a lot!
 Let's bring you up to speed with the minimum you need to know to start contributing.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,4 +54,5 @@ These are some documents using as reference for this documentation.
    mrdeveloper
    plipreview
 
-Our coding style guides are located at the `style guide section <http://docs.plone.org/develop/styleguide/index.html>`_ on docs.plone.org.
+Our coding style guides are located at :doc:`/develop/styleguide/index`.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,5 +54,5 @@ These are some documents using as reference for this documentation.
    mrdeveloper
    plipreview
 
-Our coding style guides are located at :doc:`/develop/styleguide/index`.
+Our coding style guides are located at the :doc:`Plone Style Guide </develop/styleguide/index>` section.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,4 +54,4 @@ These are some documents using as reference for this documentation.
    mrdeveloper
    plipreview
 
-Our coding style guides are located at the `style guide section <https://github.com/plone/documentation/tree/5.0/develop/styleguide>`_ on docs.plone.org.
+Our coding style guides are located at the `style guide section <http://docs.plone.org/develop/styleguide/index.html>`_ on docs.plone.org.

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -35,6 +35,8 @@ Dependencies
   including development headers.
 
 
+.. _setup-development-environment
+
 Setting up Your Development Environment
 =======================================
 The first step in fixing a bug is getting this `buildout <https://github.com/plone/buildout.coredev>`_ running.
@@ -85,9 +87,6 @@ The line with a * by it will indicate which branch you are currently working on.
 .. important::
    Make sure to rerun buildout if you were in a different branch earlier to get the correct versions of packages,
    otherwise you will get some weird behavior!
-
-For more information on buildout,
-please see the `collective developer manual documentation on buildout <http://docs.plone.org/old-reference-manuals/buildout/index.html>`_.
 
 
 Jenkins / mr.roboto

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -41,7 +41,7 @@ Setting up Your Development Environment
 =======================================
 The first step in fixing a bug is getting this `buildout <https://github.com/plone/buildout.coredev>`_ running.
 We recommend fixing the bug on the latest branch and then `backporting <http://en.wikipedia.org/wiki/Backporting>`_ as necessary.
-`Github <https://github.com/plone/buildout.coredev/>`_ by default always points to the currently active branch.
+`GitHub <https://github.com/plone/buildout.coredev/>`_ by default always points to the currently active branch.
 More information on switching release branches is below.
 
 To set up a plone 5 development environment::
@@ -72,7 +72,7 @@ you can easily switch branches. The first time you get a branch, you must do::
 
   > git checkout -t origin/4.1
 
-This should set up a local 4.1 branch tracking the one on github.
+This should set up a local 4.1 branch tracking the one on GitHub.
 From then on you can just do::
 
   > git checkout 4.1
@@ -173,7 +173,7 @@ if the issue is in ``plone.app.caching`` and ``plone.caching``::
 
 Don't forget to rerun buildout!
 In both methods,
-``mr.developer`` will download the source from github (or otherwise) and put the package in the :file:`src/` directory.
+``mr.developer`` will download the source from GitHub (or otherwise) and put the package in the :file:`src/` directory.
 You can repeat this process with as many or as few packages as you need.
 For some more tips on working with ``mr.developer``,
 please :doc:`read more here <mrdeveloper>`.
@@ -275,7 +275,7 @@ At the time of writing this document,
 there are branches for 4.2.x, 4.3.x and master,
 which is the implied 5.0.
 This may change faster than this documentation,
-so check the branch dropdown on Github.
+so check the branch dropdown on GitHub.
 
 Still with me? So you have a bug fix for 4.x.
 If the fix is only for one version,
@@ -332,7 +332,7 @@ Branches and Forks and Direct Commits - Oh My!
 ----------------------------------------------
 Plone used to be in an svn repository,
 so everyone is familiar and accustomed to committing directly to the branches.
-After the migration to github,
+After the migration to GitHub,
 the community decided to maintain this spirit.
 If you have signed the :doc:`contributor agreement <contributors_agreement_explained>` form,
 you can commit directly to the branch
@@ -347,7 +347,7 @@ If you:
  * want feedback/code review
  * are implementing a non-trivial change
 
-then you likely want to create a branch of whatever packages you are using and then use the `pull request <https://help.github.com/articles/using-pull-requests>`_ feature of github to get review.
+then you likely want to create a branch of whatever packages you are using and then use the `pull request <https://help.github.com/articles/using-pull-requests>`_ feature of GitHub to get review.
 Everything about this process would be the same except you need to work on a branch.
 Take the ``plone.app.caching`` example.
 After checking it out with ``mr.developer``,
@@ -371,8 +371,8 @@ push to a remote branch with::
 
   > git push origin my_descriptive_branch_name
 
-This will make a remote branch in github.
-Navigate to this branch in the github UI and on the top right there will be a button that says **"Pull Request"**.
+This will make a remote branch in GitHub.
+Navigate to this branch in the GitHub UI and on the top right there will be a button that says **"Pull Request"**.
 This will turn your request into a pull request on the main branch.
 There are people who look once a week or more for pending pull requests and will confirm whether or not its a good fix and give you feedback where necessary.
 The reviewers are informal and very nice so don't worry - they are there to help!
@@ -386,7 +386,7 @@ Finalizing Tickets
 ==================
 If you are working from a ticket,
 please don't forget to go back to the ticket and add a link to the changeset.
-We don't have integration with github yet so it's a nice way to track changes.
+We don't have integration with GitHub yet so it's a nice way to track changes.
 It also lets the reporter know that you care.
 If the bug is really bad,
 consider pinging the release manager and asking him to make a release pronto.
@@ -394,6 +394,6 @@ consider pinging the release manager and asking him to make a release pronto.
 FAQ
 ===
  * *How do I know when my package got made?*
-    You can follow the project on github and watch its `timeline <https://github.com/organizations/plone>`_.
+    You can follow the project on GitHub and watch its `timeline <https://github.com/organizations/plone>`_.
     You can also check the :file:`CHANGES.rst` of every plone release for a comprehensive list of all changes and validate that yours is present.
 

--- a/docs/issues.rst
+++ b/docs/issues.rst
@@ -71,7 +71,7 @@ Although this technically isn't a buildout issue,
 it happens when running buildout so I'm putting it under buildout issues.
 
 When working with the dev instance,
-especially with all the moving back and forth between github and svn,
+especially with all the moving back and forth between GitHub and svn,
 you may have an old copy of a src package.
 The error looks like::
  

--- a/docs/plipreview.rst
+++ b/docs/plipreview.rst
@@ -92,7 +92,7 @@ Python
 JavaScript
 ----------
 * Does the JavaScript meet our set of JavaScript standards?
-  See our section about :doc:`/develop/addons/javascript/index` and the :doc:`/develop/styleguide/javascript`.
+  See our section about :doc:`JavaScript </develop/addons/javascript/index>` and the :doc:`JavaScript styleguide </develop/styleguide/javascript>`.
 * Does the JavaScript work in all currently supported browsers?
   Is it performant?
 

--- a/docs/plipreview.rst
+++ b/docs/plipreview.rst
@@ -14,7 +14,7 @@ please attach your review to the PLIP ticket itself.
 
 Setting up the environment
 ==========================
-Follow the instructions on `setting up a development environment <http://docs.plone.org/develop/plone-coredev/intro.html#setting-up-your-development-environment>`_ for "Getting the Code".
+Follow the instructions on :ref:`setup-development-environment`.
 You will need to checkout the branch to which the PLIP is assigned.
 Instead of running the buildout with the default buildout file,
 you will run the config specific to that plip::
@@ -89,11 +89,11 @@ Python
 * Does the code adhere to PEP8 standards (more or less)?
 * Are they importing deprecated modules?
 
-Javascript
+JavaScript
 ----------
-* Does the javascript meet our set of javascript standards?
-  See http://docs.plone.org/5/en/develop/addons/javascript.html
-* Does the Javascript work in all currently supported browsers?
+* Does the JavaScript meet our set of JavaScript standards?
+  See our section about :doc:`/develop/addons/javascript/index` and the :doc:`/develop/styleguide/javascript`.
+* Does the JavaScript work in all currently supported browsers?
   Is it performant?
 
 ME/TAL

--- a/docs/plips.rst
+++ b/docs/plips.rst
@@ -200,11 +200,10 @@ General Rules
 
     * Have clear code
 
-    * Follow our style guides: `Style Guides <https://github.com/plone/documentation/tree/5.0/develop/styleguide>`_.
+    * Follow our style guides: `Style Guides <http://docs.plone.org/develop/styleguide/index.html>`_.
       For convenience and better code quality use Python, JavaScript and other code linting plugins in your editor.
 
-    * `Be tested <http://docs.plone.org/manage/deploying/testing_tuning/testing_and_debugging/index.html>`_
-
+    * `Be tested <http://docs.plone.org/develop/testing/index.html>`_
 
 Creating a New PLIP Branch
 --------------------------

--- a/docs/plips.rst
+++ b/docs/plips.rst
@@ -200,10 +200,10 @@ General Rules
 
     * Have clear code
 
-    * Follow our style guides: `Style Guides <http://docs.plone.org/develop/styleguide/index.html>`_.
+    * Follow our style guides: :doc:`/develop/styleguide/index`.
       For convenience and better code quality use Python, JavaScript and other code linting plugins in your editor.
 
-    * `Be tested <http://docs.plone.org/develop/testing/index.html>`_
+    * Be tested: :doc:`/develop/testing/index`.
 
 Creating a New PLIP Branch
 --------------------------

--- a/docs/plips.rst
+++ b/docs/plips.rst
@@ -200,10 +200,10 @@ General Rules
 
     * Have clear code
 
-    * Follow our style guides: :doc:`/develop/styleguide/index`.
+    * :doc:`Follow our style guides </develop/styleguide/index>`.
       For convenience and better code quality use Python, JavaScript and other code linting plugins in your editor.
 
-    * Be tested: :doc:`/develop/testing/index`.
+    * :doc:`Be tested </develop/testing/index>`.
 
 Creating a New PLIP Branch
 --------------------------

--- a/docs/roboto.rst
+++ b/docs/roboto.rst
@@ -1,12 +1,6 @@
-.. -*- coding: utf-8 -*-
-
-==========
-Mr. Roboto
-==========
-
-Github push
+GitHub push
 ===========
-When a push happens on Github,
+When a push happens on GitHub,
 ``mr.roboto`` is triggered so starts to analyze the push.
 
 * If it's on ``buildout-coredev`` it starts the job of the branch that has been pushed.
@@ -21,7 +15,7 @@ Job finishes
 When jenkins finish a job it does a callback to ``mr.roboto`` in order to :
 
 * If it comes from a ``coredev`` job,
-  all the ``coredev`` jobs related to that push are finished writes a comment on the github commit with all the information
+  all the ``coredev`` jobs related to that push are finished writes a comment on the GitHub commit with all the information
   (once and with all the information so no more empty mails from gh notification system)
 * If it comes from a kgs job and all the kgs jobs are finished,
   (that may take max 10 min)

--- a/docs/roboto.rst
+++ b/docs/roboto.rst
@@ -1,3 +1,9 @@
+.. -*- coding: utf-8 -*-
+
+==========
+Mr. Roboto
+==========
+
 GitHub push
 ===========
 When a push happens on GitHub,

--- a/docs/updateme.rst
+++ b/docs/updateme.rst
@@ -4,7 +4,7 @@
 How to Update these Docs
 ========================
 
-These documents are currently stored with the coredev buildout in github in :file:`/docs`.
+These documents are currently stored with the coredev buildout in GitHub in :file:`/docs`.
 To update them,
 please checkout the coredev buildout and update there.
 Make the changes on the latest version branch (as of this writing ``5.0``)::


### PR DESCRIPTION
- fix links
- change links from docs.plone.org to :doc: references. this makes all those references only work on docs.plone.org. i guess, that's ok...
- change different styles of how github was written to the official naming: GitHub. see: https://github.com/plone/documentation/issues/475
