### PR TITLE
change repo url from git to https

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -5,15 +5,15 @@
 ########################
 
 # Plone
-plone = git://github.com/plone
+plone = https://github.com/plone
 plone_push = git@github.com:plone
 
 # Collective
-collective = git://github.com/collective
+collective = https://github.com/collective
 collective_push = git@github.com:collective
 
 # Zope
-zope = git://github.com/zopefoundation
+zope = https://github.com/zopefoundation
 zope_push = git@github.com:zopefoundation
 
 


### PR DESCRIPTION
Using git instead of https for `git clone` creates [problem](http://stackoverflow.com/questions/5860888/git-through-proxy) in systems which are using a proxy server for server for accessing the Internet. 

> mr.developer: 
> mr.developer: 
> mr.developer: Cloned 'five.intid' with git.
> mr.developer: git cloning of 'five.intid' failed.
> mr.developer: fatal: unable to connect to github.com:
> mr.developer: github.com[0: 192.30.252.131]: errno=Connection refused
> mr.developer: 
> mr.developer: 
> mr.developer: Cloned 'mockup' with git.
> mr.developer: git cloning of 'mockup' failed.
> mr.developer: fatal: unable to connect to github.com:
> mr.developer: github.com[0: 192.30.252.129]: errno=Connection refused
> mr.developer: 
> mr.developer: 
> mr.developer: Cloned 'Products.PortalTransforms' with git.
> mr.developer: git cloning of 'Products.PortalTransforms' failed.
> mr.developer: fatal: unable to connect to github.com:
> mr.developer: github.com[0: 192.30.252.129]: errno=Connection refused
> mr.developer: 
> mr.developer: 
> mr.developer: Cloned 'archetypes.referencebrowserwidget' with git.
> mr.developer: git cloning of 'archetypes.referencebrowserwidget' failed.
> mr.developer: fatal: unable to connect to github.com:
> mr.developer: github.com[0: 192.30.252.131]: errno=Connection refused
> mr.developer: 
> mr.developer: 
> mr.developer: There have been errors, see messages above.

The error is fixed by changing the git to https in the repo urls. Other fix is to force git to use https instead of git

`git config --global url.https://github.com/.insteadOf git://github.com/`
