### PR TITLE
move grok to ecosystem.cfg

### DIFF
--- a/ecosystem.cfg
+++ b/ecosystem.cfg
@@ -73,3 +73,6 @@ plone.app.intid = git ${remotes:plone}/plone.app.intid.git pushurl=${remotes:plo
 plone.app.relationfield = git ${remotes:plone}/plone.app.relationfield.git pushurl=${remotes:plone_push}/plone.app.relationfield.git
 plone.app.referenceablebehavior = git ${remotes:plone}/plone.app.referenceablebehavior pushurl=${remotes:plone_push}/plone.app.referenceablebehavior.git
 plone.app.stagingbehavior = git ${remotes:plone}/plone.app.stagingbehavior.git pushurl=${remotes:plone_push}/plone.app.stagingbehavior.git
+plone.directives.form = git ${remotes:plone}/plone.directives.form.git pushurl=${remotes:plone_push}/plone.directives.form.git branch=master
+plone.directives.tiles = git ${remotes:plone}/plone.directives.tiles.git pushurl=${remotes:plone_push}/plone.directives.tiles.git branch=master
+

--- a/ecosystem.cfg
+++ b/ecosystem.cfg
@@ -15,6 +15,7 @@ test-eggs +=
     collective.z3cform.datagridfield [test]
     five.grok [form]
     five.intid
+    grokcore.security [test]
     plone.app.lockingbehavior [tests]
     plone.app.referenceablebehavior
     plone.app.relationfield
@@ -55,6 +56,11 @@ Dexterity-ecosystem =
     plone.formwidget.autocomplete
     plone.formwidget.contenttree
     z3c.relationfield
+Grok =
+    grokcore.view
+    grokcore.component
+    grokcore.security
+    martian
 
 [alltests]
 exclude +=

--- a/ecosystem.cfg
+++ b/ecosystem.cfg
@@ -73,6 +73,3 @@ plone.app.intid = git ${remotes:plone}/plone.app.intid.git pushurl=${remotes:plo
 plone.app.relationfield = git ${remotes:plone}/plone.app.relationfield.git pushurl=${remotes:plone_push}/plone.app.relationfield.git
 plone.app.referenceablebehavior = git ${remotes:plone}/plone.app.referenceablebehavior pushurl=${remotes:plone_push}/plone.app.referenceablebehavior.git
 plone.app.stagingbehavior = git ${remotes:plone}/plone.app.stagingbehavior.git pushurl=${remotes:plone_push}/plone.app.stagingbehavior.git
-plone.directives.form = git ${remotes:plone}/plone.directives.form.git pushurl=${remotes:plone_push}/plone.directives.form.git branch=master
-plone.directives.tiles = git ${remotes:plone}/plone.directives.tiles.git pushurl=${remotes:plone_push}/plone.directives.tiles.git branch=master
-

--- a/sources.cfg
+++ b/sources.cfg
@@ -93,6 +93,8 @@ plone.cachepurging                  = git ${remotes:plone}/plone.cachepurging.gi
 plone.caching                       = git ${remotes:plone}/plone.caching.git pushurl=${remotes:plone_push}/plone.caching.git branch=master
 plone.contentrules                  = git ${remotes:plone}/plone.contentrules.git pushurl=${remotes:plone_push}/plone.contentrules.git branch=master
 plone.dexterity                     = git ${remotes:plone}/plone.dexterity.git pushurl=${remotes:plone_push}/plone.dexterity.git branch=master
+plone.directives.form               = git ${remotes:plone}/plone.directives.form.git pushurl=${remotes:plone_push}/plone.directives.form.git branch=master
+plone.directives.tiles              = git ${remotes:plone}/plone.directives.tiles.git pushurl=${remotes:plone_push}/plone.directives.tiles.git branch=master
 plone.event                         = git ${remotes:plone}/plone.event.git pushurl=${remotes:plone_push}/plone.event.git branch=master
 plone.folder                        = git ${remotes:plone}/plone.folder.git pushurl=${remotes:plone_push}/plone.folder.git branch=master
 plone.formwidget.autocomplete       = git ${remotes:plone}/plone.formwidget.autocomplete.git pushurl=${remotes:plone_push}/plone.formwidget.autocomplete.git branch=master

--- a/sources.cfg
+++ b/sources.cfg
@@ -93,8 +93,6 @@ plone.cachepurging                  = git ${remotes:plone}/plone.cachepurging.gi
 plone.caching                       = git ${remotes:plone}/plone.caching.git pushurl=${remotes:plone_push}/plone.caching.git branch=master
 plone.contentrules                  = git ${remotes:plone}/plone.contentrules.git pushurl=${remotes:plone_push}/plone.contentrules.git branch=master
 plone.dexterity                     = git ${remotes:plone}/plone.dexterity.git pushurl=${remotes:plone_push}/plone.dexterity.git branch=master
-plone.directives.form               = git ${remotes:plone}/plone.directives.form.git pushurl=${remotes:plone_push}/plone.directives.form.git branch=master
-plone.directives.tiles              = git ${remotes:plone}/plone.directives.tiles.git pushurl=${remotes:plone_push}/plone.directives.tiles.git branch=master
 plone.event                         = git ${remotes:plone}/plone.event.git pushurl=${remotes:plone_push}/plone.event.git branch=master
 plone.folder                        = git ${remotes:plone}/plone.folder.git pushurl=${remotes:plone_push}/plone.folder.git branch=master
 plone.formwidget.autocomplete       = git ${remotes:plone}/plone.formwidget.autocomplete.git pushurl=${remotes:plone_push}/plone.formwidget.autocomplete.git branch=master

--- a/tests.cfg
+++ b/tests.cfg
@@ -12,7 +12,6 @@ test-eggs =
     five.intid
     five.localsitemanager
     five.pt
-    grokcore.security [test]
     icalendar [test]
     plone.alterego
     plone.api [test]
@@ -236,11 +235,6 @@ CMF_2 =
     Products.CMFQuickInstallerTool
 CMFEditions =
     Products.CMFDiffTool
-Grok =
-    grokcore.view
-    grokcore.component
-    grokcore.security
-    martian
 zope_tests =
     five.pt
     five.intid
@@ -394,7 +388,6 @@ exclude-groups =
     CMF
     CMF_2
     CMFEditions
-    Grok
     zope_tests
 exclude =
     AccessControl
@@ -446,7 +439,6 @@ exclude =
     experimental.cssselect
     feedparser
     five.globalrequest
-    five.grok
     future
     initgroups
     interlude


### PR DESCRIPTION
Our tests install the whole Grok stack via the test-dependency `grokcore.security [test]`.
I moved this and other references to Grok into ecosystem.cfg.

Also moved plone.directives.\* source definitions to ecosystem.cfg, since they are also not part of the Plone core. The reason is, that when checking out all the source definitions, the testrunner picks them up and tries to test, but the runner can't then find the dependency.

/cc @esteele @gforcada 
