### PR TITLE
fix buildout restart loop by syncing setuptools version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-setuptools==19.4
+setuptools==19.6.2
 zc.buildout==2.5.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -31,11 +31,13 @@ plone.recipe.alltests = 1.5
 plone.recipe.zeoserver = 1.2.8
 plone.recipe.zope2instance = 4.2.18
 plone.releaser = 1.3
+# keep in sync with requirements.txt
 setuptools = 19.6.2
 z3c.coverage = 2.0.3
 z3c.checkversions = 0.5
 z3c.ptcompat = 1.0.1
 z3c.template = 2.0.0
+# keep in sync with requirements.txt
 zc.buildout = 2.5.0
 zc.recipe.egg = 2.0.3
 


### PR DESCRIPTION
In commit e5e61899 the setuptools version was bumped, without upping the corresponding pin in requirements.txt. This resulted in an endless buildout restart loop.

This fix restores the version synchronicity between versions.cfg and requirements.txt. And documents the need to do so in versions.cfg.
