### PR TITLE
Added documentation about special packages.

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -57,9 +57,6 @@ people as they know what they are doing.  These are:
 ``plone.app.locales``:
   Please leave this to the i18n team lead, Vincent Fretin.
 
-``mockup``:
-  Needs special handling, please leave to Eric Steele or Nathan van Gheem.
-
 
 Plone core release process checklist
 ====================================

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -40,6 +40,27 @@ More information:
 * `High quality automated package releases for Python with zest.releaser <http://opensourcehacker.com/2012/08/14/high-quality-automated-package-releases-for-python-with-zest-releaser/>`_.
 
 
+Special packages
+================
+
+The Plone Release Team releases the core Plone packages.  Several
+others also have the rights to release individual packages on
+https://pypi.python.org.  If you have those rights on your account, you
+should feel free to make releases.
+
+Some packages need special care or should be done only by specific
+people as they know what they are doing.  These are:
+
+``Products.CMFPlone``, ``Plone``, and ``plone.app.upgrade``:
+  Please leave these to the release manager, Eric Steele.
+
+``plone.app.locales``:
+  Please leave this to the i18n team lead, Vincent Fretin.
+
+``mockup``:
+  Needs special handling, please leave to Eric Steele or Nathan van Gheem.
+
+
 Plone core release process checklist
 ====================================
 


### PR DESCRIPTION
Some packages may be releases by various people.
Others should be done by specific people.
Let's list them here, as I am sometimes wondering if a package needs any special care.

@esteele Can you check this one?
@vangheem I think you know this too.

I think `mockup` may need special handling. If that is true, we should document it here (adding a link is fine).

I was wondering if `plonetheme.barceloneta` and `plone.app.widgets` need special handling, but I see I have made releases of those in the past, and did not do anything special and no one complained. :-)
