### PR TITLE
Use fresh Zope2 2.13.24

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -5,6 +5,7 @@ extends = http://dist.plone.org/versions/zopetoolkit-1-0-8-zopeapp-versions.cfg
 [versions]
 # Zope overrides
 docutils = 0.12
+Zope2 = 2.13.24
 # Get support for @security decorators
 AccessControl = 3.0.12
 ExtensionClass = 4.1.2


### PR DESCRIPTION
Released two days ago. Looks like only minor updates, so should be safe to use.
First of course check if Jenkins likes the new version.

There is not really a zope2 versions.cfg file that we can take over. But when I do a bin/buildout in the 2.13 branch, the picked versions are printed. The following packages have new versions when compared to http://dist.plone.org/versions/zope-2-13-23-versions.cfg
- pytz = 2015.7 (was 2015.4). In our versions.cfg we are already pinning the newer version.
- AccessControl = 2.13.14 (was 2.13.13). We are already using version 3.x, so this does not gain us anything.
- And Zope2 = 2.13.24 of course.

We can add those updated versions in a new file on dist.plone.org and remove our own pytz override.
