### PR TITLE
Upgrade six to the latest version

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -73,7 +73,7 @@ python-dateutil = 1.5
 python-openid = 2.2.5
 repoze.xmliter = 0.6
 simplejson = 2.5.2
-six = 1.8.0
+six = 1.10.0
 WebOb = 1.4.1
 
 # Python 2.6 dependencies


### PR DESCRIPTION
I would like to upgrade six from 1.8.0 to 1.10.0.
This will fix an issue with the _winreg module:

```
2016-03-08T11:35:46 ERROR Zope.SiteErrorLog ... http://.../Control_Panel/DebugInfo/manage_main
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module Shared.DC.Scripts.Bindings, line 322, in __call__
  Module Shared.DC.Scripts.Bindings, line 359, in _bindAndExec
  Module App.special_dtml, line 185, in _exec
  Module DocumentTemplate.DT_In, line 630, in renderwob
  Module DocumentTemplate.DT_Util, line 210, in eval
   - __traceback_info__: refcount
  Module <string>, line 1, in <module>
  Module App.ApplicationManager, line 167, in refcount
  Module six, line 89, in __get__
  Module six, line 108, in _resolve
  Module six, line 79, in _import_module
ImportError: No module named _winreg
```

[This is the full changelog for six](https://bitbucket.org/gutworth/six/src/3deee854df8a5f1cc04dd721c18dee2128584
