### PR TITLE
Newer zope.keyreference + deps

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -22,6 +22,8 @@ Sphinx = 1.3.4
 zope.pagetemplate = 3.6.3
 # Support for more complex catalog queries
 Products.ZCatalog = 3.0.2
+# pin here, because not pinned anywhere else
+persistent = 4.1.1
 
 #############
 # Build Tools

--- a/versions.cfg
+++ b/versions.cfg
@@ -13,7 +13,10 @@ Acquisition = 4.2.2
 # More memory efficient version, Trac #13101
 DateTime = 4.0.1
 Products.BTreeFolder2 = 2.14.0
-# Override until ztk is updated
+# Overrides until ztk is updated
+zdaemon = 4.1.0
+transaction = 1.4.4
+zope.keyreference = 4.1.0
 Sphinx = 1.3.4
 # required for recent z3c.form and chameleon
 zope.pagetemplate = 3.6.3

--- a/versions.cfg
+++ b/versions.cfg
@@ -22,8 +22,6 @@ Sphinx = 1.3.4
 zope.pagetemplate = 3.6.3
 # Support for more complex catalog queries
 Products.ZCatalog = 3.0.2
-# pin here, because not pinned anywhere else
-persistent = 4.1.1
 
 #############
 # Build Tools


### PR DESCRIPTION
Introduce here a newer `zope.keyreference` plus its dependencies `zdaemon` and `transaction`. According to their changelogs this is without problems.
Also pinned persistent. This was fetched by coredev and was not pinned.
