### PR TITLE
pin persistent - it is a test dependency of z3c.form

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -170,6 +170,11 @@ mccabe = 0.3.1
 oauth = 1.0.1
 pathtools = 0.1.2
 pep8 = 1.7.0
+# persistent is a test dependency of z3c.form. It is not 
+# compatible with ZODB 3.10 which we are using.
+# If you have a dependency somewhere on else on persistent, 
+# you must get rid of it.
+persistent = 4.1.1
 pdbpp = 0.8.2
 pkginfo = 1.2.1
 plone.recipe.command = 1.1


### PR DESCRIPTION
persistent is a test dependency of z3c.form. So lets declare it to not have messages like:

```
Versions had to be automatically picked.
The following part definition lists the versions picked:
[versions]
persistent = 4.1.1
```

after each buildout run - and also to be explicit here.

persistent is not compatible with ZODB 3.10 which we are using.
If there is a dependency somewhere on else on persistent,  you must get rid of it
