### PR TITLE
5.0: use plone.app.z3cform 1.x

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -84,7 +84,7 @@ plone.app.viewletmanager            = git ${remotes:plone}/plone.app.viewletmana
 plone.app.vocabularies              = git ${remotes:plone}/plone.app.vocabularies.git pushurl=${remotes:plone_push}/plone.app.vocabularies.git branch=master
 plone.app.widgets                   = git ${remotes:plone}/plone.app.widgets.git pushurl=${remotes:plone_push}/plone.app.widgets.git branch=master
 plone.app.workflow                  = git ${remotes:plone}/plone.app.workflow.git pushurl=${remotes:plone_push}/plone.app.workflow.git branch=master
-plone.app.z3cform                   = git ${remotes:plone}/plone.app.z3cform.git pushurl=${remotes:plone_push}/plone.app.z3cform.git branch=master
+plone.app.z3cform                   = git ${remotes:plone}/plone.app.z3cform.git pushurl=${remotes:plone_push}/plone.app.z3cform.git branch=1.x
 plone.autoform                      = git ${remotes:plone}/plone.autoform.git pushurl=${remotes:plone_push}/plone.autoform.git branch=master
 plone.batching                      = git ${remotes:plone}/plone.batching.git pushurl=${remotes:plone_push}/plone.batching.git branch=master
 plone.behavior                      = git ${remotes:plone}/plone.behavior.git pushurl=${remotes:plone_push}/plone.behavior.git branch=master


### PR DESCRIPTION
The master branch has IMHO too many incompatible changes, and its version is already bumped to 2.0.0.
See https://github.com/plone/plone.app.z3cform/pull/43 which is marked with milestone Plone 5.1.

I have backported a test fix from master to 1.x, so we keep the checkout.
