### PR TITLE
Removed new zope.keyreference pin.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -16,7 +16,6 @@ Products.BTreeFolder2 = 2.14.0
 # Overrides until ztk is updated
 zdaemon = 4.1.0
 transaction = 1.4.4
-zope.keyreference = 4.1.0
 Sphinx = 1.3.4
 # required for recent z3c.form and chameleon
 zope.pagetemplate = 3.6.3


### PR DESCRIPTION
zope.keyreference 4.1.0 pulls in these dependencies, which seems wrong/dangerous:
- BTrees = 4.2.0
- ZODB = 4.2.0
- zodbpickle = 0.6.0

We then have both ZODB3 and ZODB in bin/instance, which does not seem like a good idea.

This reverts part of pull request #203.
cc @jensens 
