### PR TITLE
Add zope.globalrequest

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -22,6 +22,7 @@ auto-checkout =
     plone.app.testing
     plone.schemaeditor
     Products.statusmessages
+    zope.globalrequest
 # translations moved
 # documentation only
     plone.recipe.zeoserver


### PR DESCRIPTION
I cleaned up the test dependencies of zope.globalrequest to get rid of most of the zope.app.\* dependencies.
