### PR TITLE
Revert "Check if branch 2.3 of CMFUid works as it is"

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -164,7 +164,7 @@ Products.CMFFormController          = git ${remotes:plone}/Products.CMFFormContr
 Products.CMFPlacefulWorkflow        = git ${remotes:plone}/Products.CMFPlacefulWorkflow.git pushurl=${remotes:plone_push}/Products.CMFPlacefulWorkflow.git branch=master
 Products.CMFPlone                   = git ${remotes:plone}/Products.CMFPlone.git pushurl=${remotes:plone_push}/Products.CMFPlone.git branch=master
 Products.CMFQuickInstallerTool      = git ${remotes:plone}/Products.CMFQuickInstallerTool.git pushurl=${remotes:plone_push}/Products.CMFQuickInstallerTool.git branch=master
-Products.CMFUid                     = git ${remotes:plone}/Products.CMFUid.git pushurl=${remotes:plone_push}/Products.CMFUid.git branch=2.3
+Products.CMFUid                     = git ${remotes:plone}/Products.CMFUid.git pushurl=${remotes:plone_push}/Products.CMFUid.git branch=2.2
 Products.contentmigration           = git ${remotes:plone}/Products.contentmigration.git pushurl=${remotes:plone_push}/Products.contentmigration.git branch=master
 Products.DateRecurringIndex         = git ${remotes:collective}/Products.DateRecurringIndex.git pushurl=${remotes:collective_push}/Products.DateRecurringIndex.git branch=master
 Products.DCWorkflow                 = git ${remotes:zope}/Products.DCWorkflow.git pushurl=${remotes:zope_push}/Products.DCWorkflow.git branch=2.2


### PR DESCRIPTION
Reverts plone/buildout.coredev#220

Branch 2.3 of CMFUid is not ready to be integrated into Plone as it is. Some work would be needed and as the general idea is to get rid of the CMF layer, any effort would be probably best used to try that instead of fixing it.
