### PR TITLE
Revert checkout of plone.protect.

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -15,4 +15,3 @@ auto-checkout =
     plone.app.contenttypes
     plone.app.upgrade
     plone.app.discussion
-    plone.protect


### PR DESCRIPTION
Jenkins passed on the pull requests, but fails for real.

It _should_ not have anything to do with plone.protect, but let's see.
