### PR TITLE
Updated selenium versions on 4.3 to same as 5.0.

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -147,7 +147,6 @@ plone.recipe.command = 1.1
 PyYAML = 3.11
 requests = 2.9.1
 requests-toolbelt = 0.6.0
-selenium = 2.29.0
 twine = 1.6.5
 unittest-jshint = 1.0
 watchdog = 0.8.3

--- a/versions.cfg
+++ b/versions.cfg
@@ -45,9 +45,9 @@ robotframework = 3.0
 robotframework-debuglibrary = 0.4
 robotframework-ride = 1.5.2.1
 robotframework-selenium2library = 1.7.4
-robotframework-selenium2screenshots = 0.6.0
+robotframework-selenium2screenshots = 0.7.0
 robotsuite = 1.7.0
-selenium = 2.53.1
+selenium = 2.53.5
 sphinx-rtd-theme = 0.1.5
 sphinxcontrib-robotframework = 0.5.1
 


### PR DESCRIPTION
Especially remove the old separate selenium 2.29.0 pin from tests.cfg.
Should no longer be needed.
