### PR TITLE
Test Products.Archetypes in bin/alltests-at [5.0]

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -228,6 +228,7 @@ Add-ons =
     Products.CMFPlacefulWorkflow
     Products.CMFEditions
 Archetypes =
+    Products.Archetypes
     Products.MimetypesRegistry
     Products.PortalTransforms
     Products.statusmessages
@@ -421,7 +422,6 @@ exclude =
     MultiMapping
     Persistence
     Pillow
-    Products.Archetypes
     Products.BTreeFolder2
     Products.CMFCore
     Products.ExternalEditor


### PR DESCRIPTION
See https://github.com/plone/Products.PortalTransforms/pull/15
That pull request fixes a test failure in Products.Archetypes.  The test failure can be seen when doing `bin/test -s Products.Archetypes`. But you don't see it when doing `bin/alltests` or `bin/alltests-at`. When I add a pdb in `Products.Archetypes.tests.test_baseunit.py` it never gets called when running those two alltest commands.

It seems logical that `bin/alltests-at` would run the `Products.Archetypes` tests. That is what this pull request does.
I expect that the test run will fail, but that is good: it shows that the Products.Archetypes tests are finally run again. :-)

Same is true for 5.1, but let's check it in 5.0 first.
