### PR TITLE
Moved coverage 3.7.1 pin from tests.cfg to versions.cfg.

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -151,7 +151,6 @@ check-manifest = 0.31
 collective.recipe.sphinxbuilder = 0.8.2
 colorama = 0.3.7
 configparser = 3.5.0b2
-coverage = 3.7.1
 fancycompleter = 0.4
 flake8 = 2.5.4
 FormEncode = 1.3.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -14,6 +14,7 @@ Acquisition = 4.2.2
 DateTime = 4.0.1
 Products.BTreeFolder2 = 2.14.0
 # Overrides until ztk is updated
+coverage = 3.7.1
 zdaemon = 4.1.0
 transaction = 1.4.4
 Sphinx = 1.3.6


### PR DESCRIPTION
This overrides the ztk version 3.5.2, which is really old, and incompatible with current createcoverage. I think since one or two years this has already bitten add-on developers who get Travis failures for this, and need to pin either an older createcoverage, or a newer coverage.

BTW, newest coverage is 4.2, but let's start with simply moving the version pin.

See issue #235 
