### PR TITLE
No longer exclude z3c.form from the tests. [5.1]

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -515,7 +515,6 @@ exclude =
     z3c.autoinclude
     z3c.caching
     z3c.coverage
-    z3c.form
     z3c.objpath
     z3c.ptcompat
     z3c.template


### PR DESCRIPTION
It was excluded since 2012, with this commit: https://github.com/plone/buildout.coredev/commit/b8b8b1f4f93ec309538298b9171d4bbbbc93d54e
According to the commit message, we "exclude z3c.form tests, since its tests still depend on too much zope.app.\* stuff." But that is no longer true for the branches we are using on 4.3, 5.0 and 5.1.
See also discussion on https://github.com/plone/buildout.coredev/issues/235
