### PR TITLE
Test Products.CMFFormController in bin/alltests-at.

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -228,6 +228,7 @@ Add-ons =
     Products.CMFEditions
 Archetypes =
     Products.Archetypes
+    Products.CMFFormController
     Products.MimetypesRegistry
     Products.PortalTransforms
     Products.statusmessages
@@ -425,7 +426,6 @@ exclude =
     Products.CMFCore
     Products.ExternalEditor
     Products.ExternalMethod
-    Products.CMFFormController
     Products.i18ntestcase
     Products.MailHost
     Products.Marshall


### PR DESCRIPTION
It was excluded from all tests so far.
And 'bin/test -s Products.CMFFormController' passes on 4.3, but fails on 5.0 and 5.1.
