### PR TITLE
Update sources.cfg, versions.cfg

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -19,13 +19,11 @@ zope_push = git@github.com:zopefoundation
 
 
 [sources]
-AccessControl                       = git ${remotes:zope}/AccessControl.git pushurl=${remotes:zope_push}/AccessControl.git branch=master
+AccessControl                       = git ${remotes:zope}/AccessControl.git pushurl=${remotes:zope_push}/AccessControl.git branch=3.0.x
 archetypes.multilingual             = git ${remotes:plone}/archetypes.multilingual.git pushurl=${remotes:plone_push}/archetypes.multilingual.git branch=master
 archetypes.referencebrowserwidget   = git ${remotes:plone}/archetypes.referencebrowserwidget.git pushurl=${remotes:plone_push}/archetypes.referencebrowserwidget.git branch=master
 archetypes.schemaextender           = git ${remotes:plone}/archetypes.schemaextender.git pushurl=${remotes:plone_push}/archetypes.schemaextender.git branch=master
 borg.localrole                      = git ${remotes:plone}/borg.localrole.git pushurl=${remotes:plone_push}/borg.localrole.git branch=master
-collective.elephantvocabulary       = git ${remotes:collective}/collective.elephantvocabulary.git pushurl=${remotes:collective_push}/collective.elephantvocabulary.git branch=master
-collective.js.jqueryui              = git ${remotes:collective}/collective.js.jqueryui.git pushurl=${remotes:collective_push}/collective.js.jqueryui.git
 collective.monkeypatcher            = git ${remotes:plone}/collective.monkeypatcher.git pushurl=${remotes:plone_push}/collective.monkeypatcher.git branch=master
 collective.xmltestreport            = git ${remotes:collective}/collective.xmltestreport.git pushurl=${remotes:collective_push}/collective.xmltestreport.git branch=master
 diazo                               = git ${remotes:plone}/diazo.git pushurl=${remotes:plone_push}/diazo.git branch=master
@@ -149,7 +147,7 @@ z3c.form                            = git ${remotes:zope}/z3c.form.git pushurl=$
 z3c.formwidget.query                = git ${remotes:zope}/z3c.formwidget.query.git pushurl=${remotes:zope_push}/z3c.formwidget.query.git branch=master
 z3c.relationfield                   = git ${remotes:zope}/z3c.relationfield.git pushurl=${remotes:zope_push}/z3c.relationfield.git branch=master
 ZODB3                               = git ${remotes:zope}/ZODB.git pushurl=${remotes:zope_push}/ZODB.git branch=3.10
-zope.globalrequest                  = git ${remotes:zope}/zope.globalrequest.git pushurl=${remotes:zope_push}/zope.globalrequest.git branch=master
+zope.globalrequest                  = git ${remotes:zope}/zope.globalrequest.git pushurl=${remotes:zope_push}/zope.globalrequest.git branch=1.2.x
 Zope2                               = git ${remotes:zope}/Zope.git pushurl=${remotes:zope_push}/Zope.git branch=2.13
 
 # Products
@@ -185,5 +183,5 @@ Products.PortalTransforms           = git ${remotes:plone}/Products.PortalTransf
 Products.ResourceRegistries         = git ${remotes:plone}/Products.ResourceRegistries.git pushurl=${remotes:plone_push}/Products.ResourceRegistries.git branch=master
 Products.statusmessages             = git ${remotes:plone}/Products.statusmessages.git pushurl=${remotes:plone_push}/Products.statusmessages.git branch=master
 Products.validation                 = git ${remotes:plone}/Products.validation.git pushurl=${remotes:plone_push}/Products.validation.git branch=master
-Products.ZCatalog                   = git ${remotes:zope}/Products.ZCatalog.git pushurl=${remotes:zope_push}/Products.ZCatalog.git branch=master
+Products.ZCatalog                   = git ${remotes:zope}/Products.ZCatalog.git pushurl=${remotes:zope_push}/Products.ZCatalog.git branch=3.0.x
 Products.ZopeVersionControl         = git ${remotes:zope}/Products.ZopeVersionControl.git pushurl=${remotes:zope_push}/Products.ZopeVersionControl.git branch=master

--- a/versions.cfg
+++ b/versions.cfg
@@ -284,7 +284,6 @@ zope.schema                           = 4.4.2
 
 #########################################
 # Ecosystem (not officially part of core)
-collective.elephantvocabulary         = 0.2.5
 collective.js.jqueryui                = 2.0.1
 collective.z3cform.datagridfield      = 1.1
 collective.z3cform.datagridfield-demo = 0.6


### PR DESCRIPTION
Sources.cfg:
- Use Products.ZCatalog 3.0.x branch
- Remove collective.elephantvocabulary
- Remove collective.js.jqueryui
- Use zope.globalrequest 1.2.x branch

versions.cfg:
- Remove collective.elephantvocabulary

The changes with Products.ZCatalog and zope.globalrequest are necessary to allow buildout to run with `auto-checkout = *`
