### PR TITLE
Bump qa.cfg versions

### DIFF
--- a/experimental/qa.cfg
+++ b/experimental/qa.cfg
@@ -30,29 +30,39 @@ flake8-extensions =
     flake8-string-format
 
 [versions]
-flake8 = 2.5.4
-flake8-blind-except = 0.1.0
-flake8-coding = 1.1.1
+flake8 = 3.2.1
+flake8-blind-except = 0.1.1
+flake8-coding = 1.3.0
 flake8-debugger = 1.4.0
-flake8-deprecated = 0.2
-flake8-isort = 1.1.1
-flake8-pep3101 = 0.4
+flake8-deprecated = 1.1
+flake8-isort = 2.1.3
+flake8-pep3101 = 1.0
 flake8-plone-hasattr = 0.1
-flake8-print = 2.0.1
-flake8-quotes = 0.1.2
-flake8-string-format = 0.2.1
-flake8-todo = 0.4
-mccabe = 0.4.0
-pep8 = 1.7.0
+flake8-print = 2.0.2
+flake8-quotes = 0.8.1
+flake8-string-format = 0.2.3
+mccabe = 0.5.2
 plone.recipe.codeanalysis = 2.2
-pyflakes = 1.0.0
-zc.buildout = 2.5.0
+pycodestyle = 2.2.0
+pyflakes = 1.3.0
 zc.recipe.egg = 2.0.3
 
 # Required by:
-# plone.recipe.codeanalysis==2.1
-check-manifest = 0.31
+# plone.recipe.codeanalysis==2.2
+check-manifest = 0.34
 
 # Required by:
-# flake8-isort==1.0
-isort = 4.2.2
+# flake8==3.2.1
+configparser = 3.5.0
+
+# Required by:
+# flake8==3.2.1
+enum34 = 1.1.6
+
+# Required by:
+# flake8-isort==2.1.3
+flake8-polyfill = 1.0.1
+
+# Required by:
+# flake8-isort==2.1.3
+testfixtures = 4.13.1


### PR DESCRIPTION
I did not update flake8 to 3.0.4 as there are some plugins (at least flake8-print) that still do not work with it
