### PR TITLE
Move isolated packages to plone_app_testing group

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -262,6 +262,7 @@ plone_app_testing =
     diazo
     icalendar
     plone.alterego
+    plone.api
     plone.app.caching
     plone.app.content
     plone.app.contentlisting
@@ -389,8 +390,6 @@ Dexterity =
 # where XXX does not start with 'group XXX'
 #
 # Currently the list is:
-# - coverage
-# - plone.api
 # - plone.app.folder (see above regarding isolation problems)
 # - plone.app.lockingbehavior
 # - plone.app.multilingual
@@ -424,6 +423,7 @@ exclude =
     Chameleon
     ClientForm
     configparser
+    coverage
     cssmin
     cssselect
     DateTime


### PR DESCRIPTION
plone.api should not have isolation problems,
so there is no need to run it fully isolated.

coverage on the other hand should not be run at all.
