### PR TITLE
plone.folder has no test isolation problems anymore

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -307,6 +307,7 @@ plone_app_testing =
     plone.contentrules
     plone.dexterity
     plone.event
+    plone.folder
     plone.formwidget.namedfile
     plone.formwidget.recurrence
     plone.i18n
@@ -345,9 +346,6 @@ plone_app_testing =
     z3c.relationfield
 
 Dexterity =
-# Moving plone.folder into the plone_app_testing group leads to test failures with:
-# ValueError: undefined property 'content_meta_type'. This error also occurs when trying to install plone.app.collection.
-    plone.folder
 # Moving plone.schemaeditor into the plone_app_testing_group leads to test failures.
     plone.schemaeditor
 # Moving plone.session into the plone_app_testing group leads to massive test failures.


### PR DESCRIPTION
Tests on plone.folder are using plone.app.testing, so there shouldn't be problems anymore... Let's see what's Jenkins opinion on it.
