### PR TITLE
Move p.a.folder into AT test groups

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -230,6 +230,7 @@ Archetypes =
     Products.PortalTransforms
     Products.statusmessages
     Products.validation
+    plone.app.folder
 ATCT =
     Products.ATContentTypes
 AT_plone_app_testing =
@@ -363,16 +364,6 @@ Dexterity =
 #
 #   Test failure in plone.app.iterate.tests.test_iterate.TestIterations:
 #   "AttributeError: 'NoneType' object has no attribute 'get'"
-#
-# - plone.app.folder
-#
-#   Moving plone.app.folder into the plone_app_testing alltests group leads
-#   to multiple test failures, e.g. in plone.app.caching:
-#   'BadRequest: The id "f1" is invalid - it is already in use.'
-#
-#   Problems can be re-produced when running:
-#
-#     $ bin/test -s plone.app.folder -s plone.app.caching
 #
 # - plone.app.widgets:
 #


### PR DESCRIPTION
Given that p.a.folder seems to be Archetypes specific (see https://github.com/plone/Products.CMFPlone/issues/1817) instead of moving it to `plone_app_testing` group it should be moved to one AT related group.
