### PR TITLE
more branch fixes in sources.cfg

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -153,7 +153,7 @@ Zope2                               = git ${remotes:zope}/Zope.git pushurl=${rem
 # Products
 Products.Archetypes                 = git ${remotes:plone}/Products.Archetypes.git pushurl=${remotes:plone_push}/Products.Archetypes.git branch=master
 Products.ATContentTypes             = git ${remotes:plone}/Products.ATContentTypes.git pushurl=${remotes:plone_push}/Products.ATContentTypes.git branch=master
-Products.BTreeFolder2               = git ${remotes:zope}/Products.BTreeFolder2.git pushurl=${remotes:zope_push}/Products.BTreeFolder2.git branch=master
+Products.BTreeFolder2               = git ${remotes:zope}/Products.BTreeFolder2.git pushurl=${remotes:zope_push}/Products.BTreeFolder2.git branch=2.14.x
 Products.CMFCore                    = git ${remotes:zope}/Products.CMFCore.git pushurl=${remotes:zope_push}/Products.CMFCore.git branch=2.2
 Products.CMFDiffTool                = git ${remotes:plone}/Products.CMFDiffTool.git pushurl=${remotes:plone_push}/Products.CMFDiffTool.git branch=master
 Products.CMFDynamicViewFTI          = git ${remotes:plone}/Products.CMFDynamicViewFTI.git pushurl=${remotes:plone_push}/Products.CMFDynamicViewFTI.git branch=master
@@ -170,7 +170,7 @@ Products.ExtendedPathIndex          = git ${remotes:plone}/Products.ExtendedPath
 Products.ExternalEditor             = git ${remotes:zope}/Products.ExternalEditor.git pushurl=${remotes:zope_push}/Products.ExternalEditor.git branch=1.1.x
 Products.GenericSetup               = git ${remotes:zope}/Products.GenericSetup.git pushurl=${remotes:zope_push}/Products.GenericSetup.git branch=master
 Products.i18ntestcase               = git ${remotes:plone}/Products.i18ntestcase.git pushurl=${remotes:plone_push}/Products.i18ntestcase.git branch=master
-Products.MailHost                   = git ${remotes:zope}/Products.MailHost.git pushurl=${remotes:zope_push}/Products.MailHost.git branch=master
+Products.MailHost                   = git ${remotes:zope}/Products.MailHost.git pushurl=${remotes:zope_push}/Products.MailHost.git rev=2.13.2
 Products.Marshall                   = git ${remotes:plone}/Products.Marshall.git pushurl=${remotes:plone_push}/Products.Marshall.git branch=master
 Products.MimetypesRegistry          = git ${remotes:plone}/Products.MimetypesRegistry.git pushurl=${remotes:plone_push}/Products.MimetypesRegistry.git branch=master
 Products.PlacelessTranslationService= git ${remotes:plone}/Products.PlacelessTranslationService.git pushurl=${remotes:plone_push}/Products.PlacelessTranslationService.git branch=master


### PR DESCRIPTION
More changes to be able to build with ``auto-checkout = *``

In sources.cfg:

- Use Products.BTreeFolder2 2.14.x branch.
- Use Products.MailHost 2.13.2 tag. This tag is needed, because 2.13.3 depends on ExtensionClass < 4, while we depend on ExtensionClass > 4.

Refs: https://github.com/plone/buildout.coredev/pull/260