### PR TITLE
Moved p.a.referenceablebehavior and p.f.recurrence to AT tests.

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -236,6 +236,8 @@ ATCT =
 AT_plone_app_testing =
     archetypes.multilingual
     plone.app.collection
+    plone.app.referenceablebehavior
+    plone.formwidget.recurrence
     Products.CMFDynamicViewFTI
     Products.contentmigration
 CMF =
@@ -282,7 +284,6 @@ plone_app_testing =
     plone.app.portlets
     plone.app.querystring
     plone.app.redirector
-    plone.app.referenceablebehavior
     plone.app.registry
     plone.app.relationfield
     plone.app.testing
@@ -306,7 +307,6 @@ plone_app_testing =
     plone.event
     plone.folder
     plone.formwidget.namedfile
-    plone.formwidget.recurrence
     plone.i18n
     plone.indexer
     plone.intelligenttext


### PR DESCRIPTION
They both setup sample AT types for testing.
plone.app.referenceablebehavior also needs several AT catalogs, so it cannot work without AT anyway.

When they are in bin/alltests, their tests start failing when we [remove ZopeTestCase from borg.localrole](https://github.com/plone/borg.localrole/pull/5).
I could find no logical reason for that.
There error was that no instance of the sample types could be created.
They ended up in portal_types just fine, but no factory could be found.

This pull request moves both packages to bin/alltests-at.