### PR TITLE
Create test runner for Python 3

### DIFF
--- a/experimental/py3x-test.cfg
+++ b/experimental/py3x-test.cfg
@@ -23,10 +23,10 @@ auto-checkout =
     plone.memoize
 #    plone.namedfile
     plone.portlets
-    plone.registry
-    plone.rfc822
-    plone.scale
-    plone.supermodel
+#    plone.registry
+#    plone.rfc822
+#    plone.scale
+#    plone.supermodel
     plone.synchronize
     plone.uuid
 
@@ -39,10 +39,10 @@ test-eggs =
     plone.memoize
 #    plone.namedfile [test]
     plone.portlets
-    plone.registry
-    plone.rfc822
-    plone.scale [test]
-    plone.supermodel [test]
+#    plone.registry
+#    plone.rfc822
+#    plone.scale [test]
+#    plone.supermodel [test]
     plone.synchronize
     plone.uuid
 

--- a/experimental/py3x-test.cfg
+++ b/experimental/py3x-test.cfg
@@ -1,8 +1,116 @@
 [buildout]
-parts = test
-develop = .
+extends = ../sources.cfg
+develop-eggs-directory = ../develop-eggs
+bin-directory = ../bin
+parts-directory = ../parts
+sources-dir = ../src
+installed = ../.installed.cfg
+
+show-picked-versions = true
+
+parts=
+    test
+
+extensions =
+    mr.developer
+
+auto-checkout =
+    plone.alterego
+    plone.behavior
+#    plone.dexterity
+    plone.event
+    plone.intelligenttext
+    plone.memoize
+#    plone.namedfile
+    plone.portlets
+    plone.registry
+    plone.rfc822
+    plone.scale
+    plone.supermodel
+    plone.synchronize
+    plone.uuid
+
+test-eggs =
+    plone.alterego
+    plone.behavior
+#    plone.dexterity [test]
+    plone.event [test]
+    plone.intelligenttext
+    plone.memoize
+#    plone.namedfile [test]
+    plone.portlets
+    plone.registry
+    plone.rfc822
+    plone.scale [test]
+    plone.supermodel [test]
+    plone.synchronize
+    plone.uuid
+
+[environment]
+BUILDOUT_DIR = ${buildout:directory}
+zope_i18n_compile_mo_files = true
 
 [test]
 recipe = collective.xmltestreport
-eggs = REPLACE_ME [test]
-defaults = ['--auto-progress', '--xml', ]
+eggs = ${buildout:test-eggs}
+defaults = ['--auto-color', '--auto-progress', ]
+environment = environment
+
+[instance]
+var = ../var
+
+[versions]
+BTrees = 4.3.1
+DateTime = 4.1.1
+Pillow = 3.4.2
+ZConfig = 3.1.0
+ZEO = 5.0.4
+ZODB3 = 3.11.0
+ZODB = 5.1.1
+collective.xmltestreport = 1.3.3
+lxml = 3.6.4
+mock = 2.0.0
+mr.developer = 1.34
+pbr = 1.10.0
+persistent = 4.2.1
+plone.testing = 5.0.0
+python-dateutil = 2.6.0
+pytz = 2016.7
+six = 1.10.0
+transaction = 2.0.3
+z3c.zcmlhook = 1.0b1
+zc.lockfile = 1.2.1
+zc.recipe.egg = 2.0.3
+zdaemon = 4.1.0
+zodbpickle = 0.6.0
+zope.annotation = 4.4.1
+zope.browser = 2.1.0
+zope.browserpage = 4.1.0
+zope.component = 4.3.0
+zope.configuration = 4.0.3
+zope.container = 4.1.0
+zope.contentprovider = 4.0.0
+zope.contenttype = 4.2.0
+zope.deferredimport = 4.1.0
+zope.dottedname = 4.1.0
+zope.event = 4.2.0
+zope.exceptions = 4.0.8
+zope.filerepresentation = 4.1.0
+zope.i18n = 4.1.0
+zope.i18nmessageid = 4.0.3
+zope.interface = 4.3.2
+zope.lifecycleevent = 4.1.0
+zope.location = 4.0.3
+zope.pagetemplate = 4.2.1
+zope.proxy = 4.2.0
+zope.publisher = 4.3.0
+zope.ramcache = 2.1.0
+zope.schema = 4.4.2
+zope.security = 4.0.3
+zope.site = 4.0.0
+zope.size = 4.1.0
+zope.tal = 4.2.0
+zope.tales = 4.1.1
+zope.testing = 4.6.0
+zope.testrunner = 4.5.1
+zope.traversing = 4.1.0


### PR DESCRIPTION
Only the packages that are known that work on Python 3 should be added.

The idea is to start small,
keep adding packages as they are made compatible with Python 3.

**THERE'S NO NEED TO TEST IT ON THE JENKNS PULL REQUEST JOB**