### PR TITLE
fix plone.app.contentrules branch to 4.0.x as this PR makes tests not…

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -46,7 +46,7 @@ plone.app.collection                = git ${remotes:plone}/plone.app.collection.
 plone.app.content                   = git ${remotes:plone}/plone.app.content.git pushurl=${remotes:plone_push}/plone.app.content.git branch=master
 plone.app.contentlisting            = git ${remotes:plone}/plone.app.contentlisting.git pushurl=${remotes:plone_push}/plone.app.contentlisting.git branch=master
 plone.app.contentmenu               = git ${remotes:plone}/plone.app.contentmenu.git pushurl=${remotes:plone_push}/plone.app.contentmenu.git branch=2.1.x
-plone.app.contentrules              = git ${remotes:plone}/plone.app.contentrules.git pushurl=${remotes:plone_push}/plone.app.contentrules.git branch=master
+plone.app.contentrules              = git ${remotes:plone}/plone.app.contentrules.git pushurl=${remotes:plone_push}/plone.app.contentrules.git branch=4.0.x
 plone.app.contenttypes              = git ${remotes:plone}/plone.app.contenttypes.git pushurl=${remotes:plone_push}/plone.app.contenttypes.git branch=master
 plone.app.controlpanel              = git ${remotes:plone}/plone.app.controlpanel.git pushurl=${remotes:plone_push}/plone.app.controlpanel.git branch=master
 plone.app.customerize               = git ${remotes:plone}/plone.app.customerize.git pushurl=${remotes:plone_push}/plone.app.customerize.git branch=master


### PR DESCRIPTION
The PR https://github.com/plone/plone.app.contentrules/pull/23 make tests not pass on Plone 5.0, therefore I want to raise the p.a.contentrules version to 4.1 and use 4.0.x branch for Plone 5.0.

/cc @jensens 