### PR TITLE
Checkout Products.GenericSetup and Zope2. [5.1]

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -4,6 +4,8 @@ auto-checkout =
     Products.CMFPlone
     Products.ResourceRegistries
     plone.app.locales
+    Products.GenericSetup
+    Zope2
 # test-only fixes:
 # translations moved
 # documentation only


### PR DESCRIPTION
In #287 I am testing Plone 4.3.
Here I am testing Plone 5.1.
If both pass, 5.0 seems safe too.