### PR TITLE
BTrees 4.4.0 with None support again

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -21,6 +21,7 @@ MultiMapping = 3.0
 ZConfig = 3.1.0
 ZODB = 3.10.7
 ZopeUndo = 4.1
+BTrees = 4.4.0
 # Overrides until ztk is updated
 coverage = 4.2
 zdaemon = 4.1.0


### PR DESCRIPTION
Let's try BTrees 4.4.0 with None support.

From its changelog:

>     Allow None as a special key (sorted smaller than all others).
> 
>     This is a bit of a return to BTrees 3 behavior in that Nones are allowed as keys again. Other objects with default ordering are still not allowed as keys.
> 