### PR TITLE
take the few zope.app.* dependencies and set them directly.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -1,6 +1,5 @@
 [buildout]
-extends = http://dist.plone.org/versions/zopetoolkit-1-0-8-zopeapp-versions.cfg
-          http://dist.plone.org/versions/zope-2-13-24-versions.cfg
+extends = http://dist.plone.org/versions/zope-2-13-24-versions.cfg
 
 [versions]
 ################
@@ -111,7 +110,7 @@ Jinja2 = 2.8
 lxml = 3.6.4
 mailinglogger = 3.8.0
 Markdown = 2.6.7
-# ordereddict = 1.1
+olefile = 0.44
 piexif = 1.0.8
 Pillow = 3.4.2
 python-dateutil = 2.6
@@ -124,6 +123,17 @@ six = 1.10.0
 slimit = 0.8.1
 WebOb = 1.6.3
 
+# zope.app.*
+# parts needed from (but without pulling whole)
+# http://dist.plone.org/versions/zopetoolkit-1-0-8-zopeapp-versions.cfg
+roman = 1.4.0
+wsgi-intercept = 0.4
+zc.sourcefactory = 0.7.0
+zope.app.appsetup = 3.14.0
+zope.app.intid = 3.7.1
+zope.app.publisher = 3.10.2
+zope.app.wsgi = 3.9.3
+zope.app.publication = 3.12.0
 
 # Special pins, see annotations
 argparse = 1.4.0


### PR DESCRIPTION
8 dependencies are used.

This stops 'spamming' the versioncheck output with a bunch of outdated and orphaned packages. 