### PR TITLE
ZODB vs. ZODB3 confusion. 

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -18,7 +18,7 @@ Products.BTreeFolder2 = 2.14.0
 Missing = 3.1
 MultiMapping = 3.0
 ZConfig = 3.1.0
-ZODB = 3.10.7
+ZODB3 = 3.10.7
 ZopeUndo = 4.1
 BTrees = 4.4.0
 # Overrides until ztk is updated
@@ -379,3 +379,6 @@ html5lib =
     Double version numbers: 0.9999 == 1.0b5, 0.99999 == 1.0b6, etcetera.
     0.99999999/1.0b9 changes too much and cannot be used with current bleach (1.4/1.5), which is used by zest.releaser.
     bleach 1.4.3 and higher have an explicit restriction, and this can only handle the version number with nines, not the 1.0bX.
+zodb3 =
+    The 3.10.* series is the last ZODB3 series. 
+    The 3.11.0 is a metapackage for the newer separate ZODB, persistent, BTrees and ZEO packages.


### PR DESCRIPTION
There is no ZODB=3.10.7 release. Also added version annotation to state how this works.

The prior pin meant to include important bug fixes in ZODB 3.10. 