### PR TITLE
raise version of zope.configure - 

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -28,6 +28,7 @@ transaction = 1.7.0
 Sphinx = 1.5.2
 zope.app.locales = 3.7.5
 zope.component = 3.12.1
+zope.configure = 4.0.3
 zope.i18n = 4.1.0
 zope.i18nmessageid = 4.0.3
 zope.interface = 4.2.0


### PR DESCRIPTION
z3c.unconfigure 1.1 depends on >= 3.8.0