### PR TITLE
Use zc.buildout 2.8.0 and setuptools 34.2.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
-setuptools==33.1.1
-zc.buildout==2.5.3
+appdirs==1.4.0
+packaging==16.8
+pyparsing==2.1.10
+setuptools==34.2.0
+six==1.10.0
+zc.buildout==2.8.0

--- a/tests.cfg
+++ b/tests.cfg
@@ -426,7 +426,7 @@ exclude =
     Acquisition
     AuthEncoding
     argh
-    argparse
+    appdirs
     argparse
     Babel
     beautifulsoup4
@@ -503,6 +503,7 @@ exclude =
     Products.ZSQLMethods
     PyGithub
     Pygments
+    pyparsing
     python-dateutil
     python-gettext
     python-openid

--- a/versions.cfg
+++ b/versions.cfg
@@ -47,8 +47,12 @@ ZServer = 3.0
 
 # Basics
 # !! keep in sync with requirements.txt !!
-setuptools = 33.1.1
-zc.buildout = 2.5.3
+appdirs = 1.4.0
+packaging = 16.8
+pyparsing = 2.1.10
+setuptools = 34.2.0
+six = 1.10.0
+zc.buildout = 2.8.0
 
 # recipes and extensions
 collective.recipe.omelette = 0.16
@@ -120,7 +124,6 @@ pytz = 2016.10
 repoze.xmliter = 0.6
 requests = 2.12.5
 simplejson = 3.10.0
-six = 1.10.0
 slimit = 0.8.1
 WebOb = 1.6.3
 future = 0.16.0


### PR DESCRIPTION
Note that setuptools 34 is using a few more packages instead of including a copy, so we need to include those version pins.

Buildout 2.6 is the first version that can handle this newer setuptools. And there have been a few other [interesting changes lately](https://github.com/buildout/buildout/blob/master/CHANGES.rst), for example the new option `abi-tag-eggs`, so we try 2.8.0.

I would currently say:
- don't do this on coredev 4.3
- maybe wait a bit on coredev 5.0 until more people have tried it.
- on 5.1 it should be okay, unless this somehow causes problems with the UnifiedInstaller

But first: Jenkins. :-)