### PR TITLE
Revert to coverage 3.x

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -14,7 +14,7 @@ Acquisition = 4.2.2
 DateTime = 4.0.1
 Products.BTreeFolder2 = 2.14.0
 # Override until ztk is updated
-coverage = 4.2
+coverage = 3.7.1
 Sphinx = 1.3.6
 # required for recent z3c.form and chameleon
 zope.pagetemplate = 3.6.3


### PR DESCRIPTION
Undo the change to coverage in e779e2b21a891a69fb56cf7cb09b6d1ddd4823ae as this creates an impossible dependency loop with z3c.coverage 2.0.3, which requires coverage < 4.