### PR TITLE
remove z3c.coverage - 5.1 branch

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -533,7 +533,6 @@ exclude =
     WSGIProxy2
     z3c.autoinclude
     z3c.caching
-    z3c.coverage
     z3c.objpath
     z3c.ptcompat
     z3c.template

--- a/versions.cfg
+++ b/versions.cfg
@@ -64,7 +64,6 @@ plone.releaser = 1.5.4
 plone.versioncheck = 1.5.1
 twine = 1.8.1
 z3c.checkversions = 0.5
-z3c.coverage = 2.0.3
 z3c.ptcompat = 2.0
 z3c.template = 2.0.0
 zc.recipe.egg = 2.0.3


### PR DESCRIPTION
remove from test eggs + versions

Related PR: https://github.com/plone/buildout.coredev/pull/322

More on this:

- z3c.coverage removed in z3c.form: https://github.com/zopefoundation/z3c.form/commit/4e5f921e15f89f1d887060212c588a07937d4e8e
- discussion about downgrading coverage in Zope versions (closed PR): https://github.com/zopefoundation/Zope/pull/107
- discussion about downgrading coverage in buildout.coredev (might get fixed with this PR): https://github.com/plone/buildout.coredev/pull/312
- Revert of a downgrade in Zope2 plonezope4 branch: https://github.com/zopefoundation/Zope/commit/da99e8b2a71b83429fc4a7e29731399ee17578d3