### PR TITLE
Remove icalendar from checkouts

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -29,4 +29,3 @@ auto-checkout =
     Products.ATContentTypes
     plone.app.discussion
     plone.app.iterate
-    icalendar


### PR DESCRIPTION
As soon as it was added a couple of tests started failing on AT jenkins job.

With this pull request I'm trying to check if that's actually true.