### PR TITLE
Add icalendar to checkouts

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -30,3 +30,4 @@ auto-checkout =
     plone.app.discussion
     plone.app.iterate
     plone.scale
+    icalendar


### PR DESCRIPTION
It was breaking jenkins since it was in checkouts, removing it fixed it.