### PR TITLE
Revert setuptools to 26.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
-appdirs==1.4.2
-packaging==16.8
-pyparsing==2.1.10
-setuptools==34.3.0
-six==1.10.0
+setuptools==33.1.1
 zc.buildout==2.8.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -51,11 +51,7 @@ trollius = 2.1
 
 # Basics
 # !! keep in sync with requirements.txt !!
-appdirs = 1.4.2
-packaging = 16.8
-pyparsing = 2.1.10
-setuptools = 34.3.0
-six = 1.10.0
+setuptools = 33.1.1
 zc.buildout = 2.8.0
 
 # recipes and extensions
@@ -375,24 +371,23 @@ babel =
 distribute =
     We dont use distribute (outdated fork of setuptools), buts its pinned in zope tookit.
     So update to latest legacy package, which is a simple compatibility layer that installs Setuptools 0.7+
+html5lib =
+    Double version numbers: 0.9999 == 1.0b5, 0.99999 == 1.0b6, etcetera.
+    0.99999999/1.0b9 changes too much and cannot be used with current bleach (1.4/1.5), which is used by zest.releaser.
+    bleach 1.4.3 and higher have an explicit restriction, and this can only handle the version number with nines, not the 1.0bX.
+ply =
+    stick to older ply 3.4, see https://github.com/dabeaz/ply/issues/82
+setuptools =
+    Use last version w/o extra dependencies, see https://github.com/plone/buildout.coredev/pull/329
+Unidecode =
+    Unidecode 0.04.{2-9} break tests
+WebOb =
+    WebOb 1.7.0 produces test failures, see https://github.com/plone/diazo/issues/67
+zope.app.testing =
+    This package is not used in core anymore, but many addons are depending on it.
+    It's latest release is not compatible with Plone.
 zope.component =
     Major changes in 4.0.0, layer was removed from zope.component.zcml.view and zope.component.zcml.resource.
     This breaks in Plone.
 zope.globalrequest =
     Pin to 1.2, because 1.3 needs zope.testbrowser>=5.0
-ply =
-    stick to older ply 3.4, see https://github.com/dabeaz/ply/issues/82
-Unidecode =
-    Unidecode 0.04.{2-9} break tests
-WebOb =
-    WebOb 1.7.0 produces test failures, see https://github.com/plone/diazo/issues/67
-html5lib =
-    Double version numbers: 0.9999 == 1.0b5, 0.99999 == 1.0b6, etcetera.
-    0.99999999/1.0b9 changes too much and cannot be used with current bleach (1.4/1.5), which is used by zest.releaser.
-    bleach 1.4.3 and higher have an explicit restriction, and this can only handle the version number with nines, not the 1.0bX.
-zodb3 =
-    The 3.10.* series is the last ZODB3 series.
-    The 3.11.0 is a metapackage for the newer separate ZODB, persistent, BTrees and ZEO packages.
-zope.app.testing =
-    This package is not used in core anymore, but many addons are depending on it.
-    It's latest release is not compatible with Plone.


### PR DESCRIPTION
Anything prior to setuptools 33.1.1 should be fine.

Plone uses basic features of setuptools and as our Jenkins CI environment
is already pining 26.1.1 is easier to stick to this version.

As soon as PLIP 2001 https://github.com/plone/Products.CMFPlone/issues/2001 is approved and merged,
we can happily move to virtualenv which solves the problem completely.

@plone/release-team @plone/framework-team opinions? I literally spent +6 hours trying to get a new node on jenkins and failing because of this newer setuptools.

Is not failing on the current nodes because a dependency (``appdirs``) of setuptools is already installed and thus does not have to fetch it (that's the actual problem).

If this is merged, I would like to ask everyone (specially @jensens) to **NOT** bump setuptools versions without first checking with the testing team. It gives a nice feeling to use the latest versions of packages, but if that has to cause massive problems on other ends at random times, then, please don't do it.