### PR TITLE
Remove plone.openid and plone.app.openid

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -25,9 +25,7 @@ eggs +=
     Products.CMFPlacefulWorkflow
     diazo [test]
     plone.app.iterate
-    plone.app.openid
     plone.app.theming [test]
-    plone.openid
     plone.resource [test]
     plone.subrequest [test]
     plone.transformchain [test]

--- a/experimental/i18n.cfg
+++ b/experimental/i18n.cfg
@@ -34,7 +34,6 @@ plone =
     plone.i18n
     plone.locking
     plone.memoize
-    plone.openid
     plone.portlets
     plone.portlet.collection
     plone.portlet.static
@@ -55,8 +54,6 @@ plone =
     plone.app.linkintegrity
     plone.app.lockingbehavior
     plone.app.portlets
-# plone.app.openid have to be after plone.app.portlets for the moment
-    plone.app.openid
     plone.app.redirector
     plone.app.textfield
     plone.app.users

--- a/sources.cfg
+++ b/sources.cfg
@@ -63,7 +63,6 @@ plone.app.linkintegrity             = git ${remotes:plone}/plone.app.linkintegri
 plone.app.locales                   = git ${remotes:collective}/plone.app.locales.git pushurl=${remotes:collective_push}/plone.app.locales.git branch=master
 plone.app.lockingbehavior           = git ${remotes:plone}/plone.app.lockingbehavior.git pushurl=${remotes:plone_push}/plone.app.lockingbehavior.git branch=master
 plone.app.multilingual              = git ${remotes:plone}/plone.app.multilingual.git pushurl=${remotes:plone_push}/plone.app.multilingual.git branch=master
-plone.app.openid                    = git ${remotes:plone}/plone.app.openid.git pushurl=${remotes:plone_push}/plone.app.openid.git branch=master
 plone.app.portlets                  = git ${remotes:plone}/plone.app.portlets.git pushurl=${remotes:plone_push}/plone.app.portlets.git branch=master
 plone.app.querystring               = git ${remotes:plone}/plone.app.querystring.git pushurl=${remotes:plone_push}/plone.app.querystring.git branch=master
 plone.app.redirector                = git ${remotes:plone}/plone.app.redirector.git pushurl=${remotes:plone_push}/plone.app.redirector.git branch=master
@@ -104,7 +103,6 @@ plone.keyring                       = git ${remotes:plone}/plone.keyring.git pus
 plone.locking                       = git ${remotes:plone}/plone.locking.git pushurl=${remotes:plone_push}/plone.locking.git branch=master
 plone.memoize                       = git ${remotes:plone}/plone.memoize.git pushurl=${remotes:plone_push}/plone.memoize.git branch=master
 plone.namedfile                     = git ${remotes:plone}/plone.namedfile.git pushurl=${remotes:plone_push}/plone.namedfile.git branch=master
-plone.openid                        = git ${remotes:plone}/plone.openid.git pushurl=${remotes:plone_push}/plone.openid.git branch=master
 plone.outputfilters                 = git ${remotes:plone}/plone.outputfilters.git pushurl=${remotes:plone_push}/plone.outputfilters.git branch=master
 plone.portlet.collection            = git ${remotes:plone}/plone.portlet.collection.git pushurl=${remotes:plone_push}/plone.portlet.collection.git branch=master
 plone.portlet.static                = git ${remotes:plone}/plone.portlet.static.git pushurl=${remotes:plone_push}/plone.portlet.static.git branch=master

--- a/tests.cfg
+++ b/tests.cfg
@@ -36,7 +36,6 @@ test-eggs =
     plone.app.locales
     plone.app.lockingbehavior
     plone.app.multilingual
-    plone.app.openid
     plone.app.portlets [test]
     plone.app.querystring
     plone.app.redirector
@@ -74,7 +73,6 @@ test-eggs =
     plone.locking
     plone.memoize
     plone.namedfile [test]
-    plone.openid
     plone.outputfilters [test]
     plone.portlet.collection
     plone.portlet.static
@@ -237,8 +235,6 @@ eggs =
 # AT alltests groups. Those test groups are run via the alltests-at script.
 Add-ons =
     archetypes.schemaextender
-    plone.app.openid
-    plone.openid
     Products.CMFEditions
     Products.CMFPlacefulWorkflow
 Archetypes =
@@ -503,7 +499,6 @@ exclude =
     pyparsing
     python-dateutil
     python-gettext
-    python-openid
     pytz
     PyYAML
     rdflib


### PR DESCRIPTION
PLIP 1659 was approved and merged some time ago already, see:
https://github.com/plone/Products.CMFPlone/issues/1659

Still, while a regular instance of Plone 5.1 does not have openid related packages,
here on buildout.coredev and specially on tests there were these references now removed.