### PR TITLE
Add more flake8 plugins

### DIFF
--- a/experimental/qa.cfg
+++ b/experimental/qa.cfg
@@ -20,6 +20,7 @@ clean-lines = True
 flake8-extensions =
     flake8-blind-except
     flake8-coding
+    flake8-commas
     flake8-debugger
     flake8-deprecated
     flake8-isort
@@ -28,11 +29,14 @@ flake8-extensions =
     flake8-print
     flake8-quotes
     flake8-string-format
+    flake8-todo
+    flake8_strict
 
 [versions]
 flake8 = 3.3.0
 flake8-blind-except = 0.1.1
 flake8-coding = 1.3.0
+flake8-commas = 0.4.3
 flake8-debugger = 1.4.0
 flake8-deprecated = 1.2
 flake8-isort = 2.2.1
@@ -41,6 +45,8 @@ flake8-plone-hasattr = 0.2.post0
 flake8-print = 2.0.2
 flake8-quotes = 0.11.0
 flake8-string-format = 0.2.3
+flake8-todo = 0.7
+flake8_strict = 0.1.4
 mccabe = 0.6.1
 plone.recipe.codeanalysis = 2.2
 pycodestyle = 2.3.1

--- a/experimental/qa.cfg
+++ b/experimental/qa.cfg
@@ -17,6 +17,9 @@ pre-commit-hook = False
 jenkins = True
 check-manifest = True
 clean-lines = True
+# keep this list in sync with what plone.recipe.codeanalysis defines
+# on its [recommended] extra, see:
+# https://github.com/plone/plone.recipe.codeanalysis/blob/master/setup.py
 flake8-extensions =
     flake8-blind-except
     flake8-coding

--- a/experimental/qa.cfg
+++ b/experimental/qa.cfg
@@ -30,21 +30,21 @@ flake8-extensions =
     flake8-string-format
 
 [versions]
-flake8 = 3.2.1
+flake8 = 3.3.0
 flake8-blind-except = 0.1.1
 flake8-coding = 1.3.0
 flake8-debugger = 1.4.0
-flake8-deprecated = 1.1
-flake8-isort = 2.1.3
-flake8-pep3101 = 1.0
-flake8-plone-hasattr = 0.1
+flake8-deprecated = 1.2
+flake8-isort = 2.2.1
+flake8-pep3101 = 1.1
+flake8-plone-hasattr = 0.2.post0
 flake8-print = 2.0.2
-flake8-quotes = 0.8.1
+flake8-quotes = 0.11.0
 flake8-string-format = 0.2.3
-mccabe = 0.5.2
+mccabe = 0.6.1
 plone.recipe.codeanalysis = 2.2
-pycodestyle = 2.2.0
-pyflakes = 1.3.0
+pycodestyle = 2.3.1
+pyflakes = 1.5.0
 zc.recipe.egg = 2.0.3
 
 # Required by:


### PR DESCRIPTION
The ones missing from plone.recipe.codeanalysis [recommended] extra.

Only the flake8-plone-api is left out.

