### PR TITLE
Pin plone api on 4.3

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -114,6 +114,7 @@ plone.app.viewletmanager            = git ${remotes:plone}/plone.app.viewletmana
 plone.app.vocabularies              = git ${remotes:plone}/plone.app.vocabularies.git pushurl=${remotes:plone_push}/plone.app.vocabularies.git branch=2.1.x
 plone.app.workflow                  = git ${remotes:plone}/plone.app.workflow.git pushurl=${remotes:plone_push}/plone.app.workflow.git branch=2.1.x
 plone.app.z3cform                   = git ${remotes:plone}/plone.app.z3cform.git pushurl=${remotes:plone_push}/plone.app.z3cform.git branch=0.x
+plone.api                           = git ${remotes:plone}/plone.api.git pushurl=${remotes:plone_push}/plone.api.git branch=master
 plone.directives.form               = git ${remotes:plone}/plone.directives.form.git pushurl=${remotes:plone_push}/plone.directives.form.git branch=master
 plone.formwidget.autocomplete       = git ${remotes:plone}/plone.formwidget.autocomplete.git pushurl=${remotes:plone_push}/plone.formwidget.autocomplete.git branch=master
 plone.formwidget.contenttree        = git ${remotes:plone}/plone.formwidget.contenttree.git pushurl=${remotes:plone_push}/plone.formwidget.contenttree.git branch=master

--- a/versions.cfg
+++ b/versions.cfg
@@ -268,6 +268,7 @@ plone.app.relationfield               = 1.2.3
 plone.app.stagingbehavior             = 0.1
 plone.app.versioningbehavior          = 1.2.0
 plone.app.widgets                     = 1.8.0
+plone.api                             = 1.8
 plone.directives.dexterity            = 1.0.2
 plone.directives.form                 = 2.0.3
 plone.event                           = 1.3.4


### PR DESCRIPTION
Not part of core in Plone 4.3, and nothing should depend on it, but it is useful to have this pin end up in the official versions. See issues #358.

Note: at first I added it to `tests.cfg` as well, but the `plone.api` tests fail with Python 2.6. If wanted, this should be fixable by conditionally adding `unittest2` as dependency. But Python 2.6 is less and less an option these days.