### PR TITLE
Docs: Fix link and typo

### DIFF
--- a/docs/contributors_agreement_explained.rst
+++ b/docs/contributors_agreement_explained.rst
@@ -1,7 +1,6 @@
 .. -*- coding: utf-8 -*-
-
 ===========================================
-Contributor’s Agreement for Plone Explained
+Contributor’s Agreement For Plone Explained
 ===========================================
 
 Prospective contributors to the Plone core code base are required to sign a contributor’s agreement,
@@ -10,7 +9,8 @@ which assigns copyright in the code to the Plone Foundation, the non-profit orga
 This document explains the purposes of this, along with questions and answers about what this means.
 
 The Plone Contributor Agreement can be found at:
-`https://plone.org/foundation/contributors-agreement/agreement.pdf`_
+`<https://plone.org/foundation/contributors-agreement/agreement.pdf>`_.
+
 
 About the Plone Contributor Agreement
 =====================================
@@ -62,7 +62,7 @@ Do I have to sign the contributor's agreement to submit a patch to the Plone cor
 
   We enthusiastically welcome patches,
   but we can't merge them until you sign and return a contributor's agreement.
-  (Unless, in the judgement of the Plone Release Manager, the patch is so tiny as not to constitute a "creative work".
+  (Unless, in the judgment of the Plone Release Manager, the patch is so tiny as not to constitute a "creative work".
   See the `Policy for Contributor Agreements and Patches`_ for more detail on this policy.)
 
 Can I grant the Plone foundation a non-exclusive license to my contributions rather than an exclusive license,
@@ -73,7 +73,7 @@ so that I can contribute the same code to other projects under different terms o
 Does the Foundation control use of the Plone trademark?
 
   Yes.
-  In order to keep the trademark,
+  to keep the trademark,
   the Foundation (or any trademark owner) must demonstrate that they have acted to protect it.
 
 Will Plone always be available under an OSI-approved/Open Source license?
@@ -142,4 +142,3 @@ How much would a non-GPL version of Plone cost?
 .. _https://github.com/plone: https://github.com/plone
 .. _https://github.com/collective: https://github.com/collective
 .. _Policy for Contributor Agreements and Patches : http://plone.org/foundation/materials/foundation-resolutions/patch-policy-052011
-

--- a/docs/contributors_agreement_explained.rst
+++ b/docs/contributors_agreement_explained.rst
@@ -12,10 +12,11 @@ The Plone Contributor Agreement can be found at:
 `<https://plone.org/foundation/contributors-agreement/agreement.pdf>`_.
 
 
-About the Plone Contributor Agreement
+About The Plone Contributor Agreement
 =====================================
 
 The Foundation feels that it benefits the community for a single organization to hold the rights to Plone.
+
 Prior to the Foundation, the intellectual property of Plone was jointly held by individual developers and by Alan Runyan and Alexander Limi.
 
 The community members who formed the Foundation felt that having the Foundation hold these rights provides several benefits:
@@ -34,109 +35,107 @@ The community members who formed the Foundation felt that having the Foundation 
 Questions & Answers
 ===================
 
-What does the contributor's agreement cover?
 
-  This agreement is for the Plone core codebase only.
-  The Plone core codebase is that code which lives in the Plone core version repositories,
-  currently located at `https://github.com/plone`_.
-  Contributions to the "Collective",
-  currently located at `https://github.com/collective`_ are not assigned to the Plone Foundation,
-  and are made available under whatever license the project developers wish to use,
-  although add-on products that import from GPLed Plone code are of course subject to the terms of the GPL,
-  which requires derived works to be GPL licensed.
 
-What rights will I continue to have for my contributions?
+**What does the contributor's agreement cover?**
 
-  Contributors are asked to transfer their intellectual property rights to the Foundation.
-  In return,
-  they will be given back irrevocable rights to use and distribute their contributions.
-  They can even give their contributions to other Open Source projects
-  (as long as those projects are compatible with the license Plone itself is issued under)
-  or use them in non-Open Source commercial applications
-  (if that is compatible with the license Plone is under).
+*This agreement is for the Plone core codebase only.*
 
-Do I have to sign the contributor's agreement to make changes to the Plone core codebase?
-  Yes.
+*The Plone core codebase is that code which lives in the Plone core version repositories,
+currently located at `https://github.com/plone`_.*
 
-Do I have to sign the contributor's agreement to submit a patch to the Plone core codebase?
+*Contributions to the "Collective", currently located at `https://github.com/collective`_
+are not assigned to the Plone Foundation, and are made available under whatever license the project developers wish to use,
+although add-on products that import from GPLed Plone code are of course subject to the terms of the GPL,
+which requires derived works to be GPL licensed.*
 
-  We enthusiastically welcome patches,
-  but we can't merge them until you sign and return a contributor's agreement.
-  (Unless, in the judgment of the Plone Release Manager, the patch is so tiny as not to constitute a "creative work".
-  See the `Policy for Contributor Agreements and Patches`_ for more detail on this policy.)
+**What rights will I continue to have for my contributions?**
 
-Can I grant the Plone foundation a non-exclusive license to my contributions rather than an exclusive license,
-so that I can contribute the same code to other projects under different terms or use the contribution for other commercial endeavors?
+*Contributors are asked to transfer their intellectual property rights to the Foundation.*
 
-  Not under the current version of the contributors agreement.
+*In return, they will be given back irrevocable rights to use and distribute their contributions.*
+*They can even give their contributions to other Open Source projects
+(as long as those projects are compatible with the license Plone itself is issued under)
+or use them in non-Open Source commercial applications
+(if that is compatible with the license Plone is under).*
 
-Does the Foundation control use of the Plone trademark?
+**Do I have to sign the contributor's agreement to make changes to the Plone core codebase?**
 
-  Yes.
-  To keep the trademark,
-  the Foundation (or any trademark owner) must demonstrate that they have acted to protect it.
+*Yes.*
 
-Will Plone always be available under an OSI-approved/Open Source license?
-Couldn't the Board change its mind about this?
+**Do I have to sign the contributor's agreement to submit a patch to the Plone core codebase?**
 
-  Plone will always be available under an OSI-approved license;
-  this is written into the language of the contributor agreement each developer and the foundation sign.
+*We enthusiastically welcome patches, but we can't merge them until you sign and return a contributor's agreement.*
 
-Will Plone ever be available under a non-GPL license?
+*(Unless, in the judgment of the Plone Release Manager, the patch is so tiny as not to constitute a "creative work".*
+*See the `Policy for Contributor Agreements and Patches`_ for more detail on this policy.)*
 
-  The current Plone approach states that companies can negotiate a non-GPL license.
-  Thus,
-  the Foundation might pursue a dual-licensing (GPL and non-GPL) scheme -
-  but,
-  at this time,
-  the Board has not yet created any policies on this.
-  This is an important question for the community,
-  of course,
-  and the Foundation intends to have this conversation in a transparent way.
+**Can I grant the Plone foundation a non-exclusive license to my contributions rather than an exclusive license,
+so that I can contribute the same code to other projects under different terms or
+use the contribution for other commercial endeavors?**
 
-Why would anyone want a non-GPL Plone?
+*Not under the current version of the contributors agreement.*
 
-  Two possible reasons:
-  some companies are reluctant to do in-house modifications of framework-like systems (such as Plone) that are under the GPL,
-  fearing that a clause in the GPL might force them to disclose their internal work -
-  thus wanting to license it under (for example) a BSD-style license.
-  Second,
-  companies may wish to offer a commercial version of Plone,
-  under a conventional shrink-wrap license,
-  without the obligation to reveal source code or share changes.
+**Does the Foundation control use of the Plone trademark?**
 
-How much would a non-GPL version of Plone cost?
+*Yes.*
 
-  Would a small company be able to afford one? --
-  Neither the Foundation nor the Board have made any decisions about a non-GPL version,
-  let alone about pricing.
-  However,
-  one of the Foundation's stated goals is to maintain a level playing field for Plone while trying to benefit all of the Plone commons.
-  If a non-GPL version was available,
-  and a large company bought it,
-  added features to it,
-  and sold it,
-  wouldn't they be using our work without an obligation to give back?
-  It's helpful to remember the core value open source provides:
-  distributed development,
-  maintenance,
-  security checking,
-  and support.
-  Companies that build large features for Plone are **already** having to make decisions of whether to release their products under an open source license or not
-  (since they could always release them as a Product,
-  not as a modification to the Plone core).
-  Despite this,
-  though,
-  many large and excellent contributions - such as Archetypes -
-  have been made,
-  and the Foundation hopes that companies will continue to do so.
-  In any event,
-  a company that purchases a non-GPL license
-  (should such ever become available)
-  is contributing financial resources to our community,
-  which can be used to further develop,
-  market,
-  and protect the GPL version of Plone.
+*To keep the trademark, the Foundation (or any trademark owner) must demonstrate that they have acted to protect it.*
+
+**Will Plone always be available under an OSI-approved/Open Source license?**
+
+*Couldn't the Board change its mind about this?**
+
+*Plone will always be available under an OSI-approved license;
+this is written into the language of the contributor agreement each developer and the foundation sign.*
+
+**Will Plone ever be available under a non-GPL license?**
+
+*The current Plone approach states that companies can negotiate a non-GPL license.*
+
+*Thus, the Foundation might pursue a dual-licensing (GPL and non-GPL) scheme -but,
+at this time, the Board has not yet created any policies on this.*
+
+*This is an important question for the community, of course,
+and the Foundation intends to have this conversation in a transparent way.*
+
+**Why would anyone want a non-GPL Plone?**
+
+*Two possible reasons:*
+
+*Some companies are reluctant to do in-house modifications of framework-like systems (such as Plone) that are under the GPL,
+fearing that a clause in the GPL might force them to disclose their internal work
+-thus wanting to license it under (for example) a BSD-style license.*
+
+*Second, companies may wish to offer a commercial version of Plone, under a conventional shrink-wrap license,
+without the obligation to reveal source code or share changes.*
+
+**How much would a non-GPL version of Plone cost?**
+
+*Would a small company be able to afford one?*
+
+*Neither the Foundation nor the Board have made any decisions about a non-GPL version,
+let alone about pricing.*
+
+*However, one of the Foundation's stated goals is to maintain a level playing field for Plone
+while trying to benefit all of the Plone commons.*
+
+*If a non-GPL version was available, and a large company bought it, added features to it, and sold it,
+wouldn't they be using our work without an obligation to give back?*
+
+*It's helpful to remember the core value open source provides: distributed development,
+maintenance, security checking, and support.*
+
+*Companies that build large features for Plone are **already** having to make decisions
+of whether to release their products under an open source license or not (since they could always release them as a Product,
+not as a modification to the Plone core).*
+
+*Despite this, though, many large and excellent contributions - such as Archetypes - have been made,
+and the Foundation hopes that companies will continue to do so.*
+
+*In any event, a company that purchases a non-GPL license (should such ever become available)
+is contributing financial resources to our community, which can be used to further develop,
+market, and protect the GPL version of Plone.*
 
 .. _http://plone.org/foundation/contributors-agreement/agreement.pdf: http://plone.org/foundation/contributors-agreement/agreement.pdf
 .. _https://github.com/plone: https://github.com/plone

--- a/docs/contributors_agreement_explained.rst
+++ b/docs/contributors_agreement_explained.rst
@@ -73,7 +73,7 @@ so that I can contribute the same code to other projects under different terms o
 Does the Foundation control use of the Plone trademark?
 
   Yes.
-  to keep the trademark,
+  To keep the trademark,
   the Foundation (or any trademark owner) must demonstrate that they have acted to protect it.
 
 Will Plone always be available under an OSI-approved/Open Source license?


### PR DESCRIPTION
This PR fixes the reST syntax of the link to: https://plone.org/foundation/contributors-agreement/agreement.pdf and a typo.

