### PR TITLE
plone.locking tests are safe

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -316,6 +316,7 @@ plone_app_testing =
     plone.indexer
     plone.intelligenttext
     plone.keyring
+    plone.locking
     plone.memoize
     plone.namedfile
     plone.outputfilters
@@ -393,7 +394,6 @@ Dexterity =
 plone_app_testing_test_isolation_problems =
     plone.app.versioningbehavior
     plone.app.widgets
-    plone.locking
 
 
 [alltests-base]


### PR DESCRIPTION
They, hopefully, do not cause any test isolation problems