### PR TITLE
plone.app.event translations moved [5.1]

### DIFF
--- a/experimental/i18n.cfg
+++ b/experimental/i18n.cfg
@@ -47,6 +47,7 @@ plone =
     plone.app.customerize
     plone.app.dexterity
     plone.app.discussion
+    plone.app.event
     plone.app.i18n
     plone.app.imaging
     plone.app.iterate
@@ -83,8 +84,6 @@ plone =
     plone.schema
     plone.schemaeditor
     plone.resource
-plone.app.event =
-    plone.app.event
 plone.app.caching =
     plone.app.caching
 plone.app.ldap =
@@ -110,7 +109,6 @@ auto-checkout +=
     ${domain:cmfplacefulworkflow}
     ${domain:cmfeditions}
     ${domain:plone}
-    ${domain:plone.app.event}
     ${domain:plone.app.caching}
     ${domain:plone.app.ldap}
 
@@ -132,7 +130,6 @@ inline =
     cmfplacefulworkflow="${domain:cmfplacefulworkflow}"
     cmfeditions="${domain:cmfeditions}"
     plone="${domain:plone}"
-    ploneappevent="${domain:plone.app.event}"
     ploneappcaching="${domain:plone.app.caching}"
     ploneappldap="${domain:plone.app.ldap}"
     if [ "$domain" == "atcontenttypes" ]; then
@@ -151,10 +148,6 @@ inline =
         packages=$plone
         options="--merge2 $localesdirectory/plone-generated.pot"
         exclude="rss.xml.pt search-rss.pt itunes.xml.pt RSS.pt rss.pt index.html metadirectives.py"
-    fi
-    if [ "$domain" == "plone.app.event" ]; then
-        packages=$ploneappevent
-        localesdirectory="${buildout:directory}/../src/plone.app.event/plone/app/event/locales"
     fi
     if [ "$domain" == "plone.app.caching" ]; then
         packages=$ploneappcaching
@@ -184,7 +177,6 @@ inline =
     cmfplacefulworkflow
     cmfeditions
     plone
-    plone.app.event
     plone.app.caching
     plone.app.ldap
     widgets"


### PR DESCRIPTION
They use the plone domain now.

See https://github.com/plone/plone.app.event/pull/204

Merge together with https://github.com/plone/plone.app.event/pull/204 and the plone.app.locales pull request (is on the making).