### PR TITLE
Use latest setuptools 39.0.1 and zc.buildout 2.11.2. [5.2]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-setuptools==38.4.0
-zc.buildout==2.11.0
+setuptools==39.0.1
+zc.buildout==2.11.2

--- a/versions.cfg
+++ b/versions.cfg
@@ -40,8 +40,8 @@ zope.untrustedpython = 4.0.0
 
 # Basics
 # !! keep in sync with requirements.txt !!
-setuptools = 38.4.0
-zc.buildout = 2.11.0
+setuptools = 39.0.1
+zc.buildout = 2.11.2
 
 # recipes and extensions
 cachecontrol = 0.12.4


### PR DESCRIPTION
There are some [changes in setuptools 39](https://github.com/pypa/setuptools/blob/v39.0.1/CHANGES.rst) that may be good, but that could also break some stuff. `zc.buildout` got a fix for it. Seems fine locally. Let's test it on Jenkins.