### PR TITLE
Checkout zc.relation and zc.relationship from the proper repo

### DIFF
--- a/py3.cfg
+++ b/py3.cfg
@@ -171,6 +171,7 @@ auto-checkout +=
     z3c.objpath
     z3c.relationfield
     zc.relation
+    zc.relationship
 
 extensions -=
     plone.versioncheck
@@ -293,6 +294,7 @@ z3c.caching                   = git ${remotes:zope}/z3c.caching.git             
 z3c.jbot                      = git ${remotes:zope}/z3c.jbot.git                        pushurl=${remotes:zope_push}/z3c.jbot.git                       branch=python3
 z3c.objpath                   = git ${remotes:zope}/z3c.objpath.git                     pushurl=${remotes:zope_push}/z3c.objpath.git                    branch=master
 z3c.relationfield             = git ${remotes:zope}/z3c.relationfield.git               pushurl=${remotes:zope_push}/z3c.relationfield.git              branch=master
-zc.relation                   = git https://github.com/ale-rt/zc.relation.git           branch=py3-compat
+zc.relation                   = git ${remotes:zope}/zc.relation.git                     pushurl=${remotes:zope_push}/zc.relation.git                    branch=py3-compat
+zc.relationship               = git ${remotes:zope}/zc.relationship.git                 pushurl=${remotes:zope_push}/zc.relationship.git                branch=py3-compat
 
 [versions]


### PR DESCRIPTION
I pushed the branch `py3-compat` from from https://github.com/ale-rt/zc.relation.git to the zopefoundation branch