### PR TITLE
Allow pypi.org and files.pythonhosted.org for buildout

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -25,6 +25,8 @@ allow-hosts =
     *.python.org
     *.plone.org
     *.zope.org
+    pypi.org
+    files.pythonhosted.org
     launchpad.net
     code.google.com
     robotframework.googlecode.com


### PR DESCRIPTION
With the recent changes to the PyPa infrastructure, we also need to whitelist pypi.org and files.pythonhosted.org for buildout.