### PR TITLE
Use Zope2 2.13.28 [4.3]

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -8,6 +8,7 @@ extends = http://dist.plone.org/versions/zopetoolkit-1-0-8-zopeapp-versions.cfg
 [versions]
 # Zope overrides
 docutils = 0.12
+Zope2 = 2.13.28
 # Get support for @security decorators
 AccessControl = 3.0.11
 # More memory efficient version, Trac #13101


### PR DESCRIPTION
This can be done differently, by pointing to a new Zope2 versions file, see #462, but for now it is at least good to test the new Zope version.