### PR TITLE
Pin Products.ZCatalog back to 4.0.1.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -176,6 +176,6 @@ Products.PythonScripts              = git ${remotes:zope}/Products.PythonScripts
 Products.ResourceRegistries         = git ${remotes:plone}/Products.ResourceRegistries.git pushurl=${remotes:plone_push}/Products.ResourceRegistries.git branch=master
 Products.statusmessages             = git ${remotes:plone}/Products.statusmessages.git pushurl=${remotes:plone_push}/Products.statusmessages.git branch=master
 Products.validation                 = git ${remotes:plone}/Products.validation.git pushurl=${remotes:plone_push}/Products.validation.git branch=master
-Products.ZCatalog                   = git ${remotes:zope}/Products.ZCatalog.git pushurl=${remotes:zope_push}/Products.ZCatalog.git branch=3.0.x
+Products.ZCatalog                   = git ${remotes:zope}/Products.ZCatalog.git pushurl=${remotes:zope_push}/Products.ZCatalog.git branch=master
 Products.ZCTextIndex                = git ${remotes:zope}/Products.ZCTextIndex.git pushurl=${remotes:zope_push}/Products.ZCTextIndex.git branch=2.13
 Products.ZopeVersionControl         = git ${remotes:zope}/Products.ZopeVersionControl.git pushurl=${remotes:zope_push}/Products.ZopeVersionControl.git branch=master

--- a/versions.cfg
+++ b/versions.cfg
@@ -11,6 +11,9 @@ docutils = 0.14
 zLOG = 3.0
 ZopeUndo = 4.3
 BTrees = 4.4.1
+# GenericSetup has test failures with Products.ZCatalog 4.1
+# See https://github.com/zopefoundation/Products.GenericSetup/issues/62
+Products.ZCatalog = 4.0.1
 # Overrides until ztk is updated
 Products.ExternalMethod = 4.0
 Products.MailHost = 4.0


### PR DESCRIPTION
GenericSetup has test failures with Products.ZCatalog 4.1
See https://github.com/zopefoundation/Products.GenericSetup/issues/62

Since we are already using ZCatalog 4.x, updated the source branch from 3.0.x to master.