### PR TITLE
Remove eggs from buildout.cfg [test] section

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -21,13 +21,4 @@ build = ${buildout:directory}/docs/build
 zope_i18n_compile_mo_files = true
 
 [test]
-eggs +=
-    Products.CMFPlacefulWorkflow
-    diazo [test]
-    plone.app.iterate
-    plone.app.theming [test]
-    plone.resource [test]
-    plone.subrequest [test]
-    plone.transformchain [test]
-    repoze.xmliter
 environment = test-env


### PR DESCRIPTION
 they are already specified in tests.cfg
Some of the duplicates in buildout.cfg did not specify the [test] extra. They do that in tests.cfg - I don't think this difference matters?
