### PR TITLE
Try to fix 5.2 branch

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -49,4 +49,4 @@ auto-checkout =
     plone.formwidget.namedfile
     plone.tiles
     Products.ExtendedPathIndex
-    plone.indexer
+


### PR DESCRIPTION
Since a few builds one of the jenkins jobs targetting 5.2 branch is failing, my guess is that https://github.com/plone/plone.indexer/pull/6 was the problem as it was merged although the 5.2 jenkins job pull request failed, was there a good reason to ignore it? @jensens 

Let's see if, indeed, removing ``plone.indexer`` fixes the problem.