### PR TITLE
fix z3c.relationfield checkout for py3

### DIFF
--- a/py3.cfg
+++ b/py3.cfg
@@ -451,7 +451,7 @@ z3c.formwidget.query          = git ${remotes:zope}/z3c.formwidget.query.git    
 # https://github.com/zopefoundation/z3c.jbot/pull/5
 z3c.jbot                      = git ${remotes:zope}/z3c.jbot.git                        pushurl=${remotes:zope_push}/z3c.jbot.git                       branch=python3
 # https://github.com/zopefoundation/z3c.relationfield/pull/12
-z3c.relationfield             = git ${remotes:zope}/z3c.relationfield.git               pushurl=${remotes:zope_push}/z3c.relationfield.git
+z3c.relationfield             = git ${remotes:zope}/z3c.relationfield.git               pushurl=${remotes:zope_push}/z3c.relationfield.git              branch=python3
 # No PR
 zope.interface                = git ${remotes:zope}/zope.interface.git                  pushurl=${remotes:zope_push}/zope.interface.git                 branch=plone-py3
 zope.publisher                = git ${remotes:zope}/zope.publisher.git                  pushurl=${remotes:zope_push}/zope.publisher.git                 branch=master


### PR DESCRIPTION
wanted to help out here https://github.com/plone/plone.outputfilters/issues/27 and realized, z3c.relationfield has the wrong branch checked out ...