### PR TITLE
Drop interlude

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -11,7 +11,6 @@ test-eggs =
     five.intid
     five.localsitemanager
     icalendar [test]
-    interlude
     plone.alterego
     plone.api [test]
     plone.app.blob [test]
@@ -438,7 +437,6 @@ exclude =
     GitPython
     idna
     initgroups
-    interlude
     ipaddress
     jsonschema
     keyring


### PR DESCRIPTION
Seems that no package depends on it and is only added on our test suite
as it is specifically added there.

The version pin is left in case someone is still using it, to not get an
unexpected version bump.