### PR TITLE
Ignore packages

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -414,6 +414,7 @@ exclude =
     cssselect
     DateTime
     decorator
+    Deprecated
     doctest
     DocumentTemplate
     docutils
@@ -517,6 +518,7 @@ exclude =
     wheel
     WebOb
     WebTest
+    wrapt
     wsgi-intercept
     WSGIProxy2
     z3c.autoinclude


### PR DESCRIPTION
Add some packages on the plone_app_testing group and exclude some
new external dependencies that do not need to be tested (and actually
make the build fail on CI).