### PR TITLE
allow custom eggs

### DIFF
--- a/buildout-py2.cfg
+++ b/buildout-py2.cfg
@@ -31,6 +31,7 @@ user = ${buildout:plone-user}
 http-address = 8080
 eggs =
     Plone
+    ${buildout:custom-eggs}
     ${buildout:devtool-eggs}
 deprecation-warnings = on
 environment-vars =

--- a/core.cfg
+++ b/core.cfg
@@ -41,6 +41,10 @@ show-picked-versions = true
 # define a template directory here in order to override it later in custom
 template-directory = ${buildout:directory}/templates
 
+# hook for custom eggs. In local.cfg this can be extended
+# with += to add custom eggs for whatever intend.
+custom-eggs =
+
 # non-immersive development helpers commonly needed for Plone Core Development
 devtool-eggs =
     pdbpp
@@ -57,6 +61,7 @@ wsgi = on
 control-script = wsgi.py
 eggs =
     Plone
+    ${buildout:custom-eggs}
     ${buildout:devtool-eggs}
 # zeo-client = on
 # zeo-address = 8100

--- a/tests.cfg
+++ b/tests.cfg
@@ -116,6 +116,7 @@ test-eggs =
     Products.ZopeVersionControl
     repoze.xmliter
     slimit
+    ${buildout:custom-eggs}
 
 [versions]
 # egg versions that are not part of the release, but should still be pinned


### PR DESCRIPTION
replaces #538 

in a `local.cfg` one now can add something like this:

```
[buildout]
extends = buildout.cfg
custom-eggs +=
    collective.easyform
```

Those are added to wsgi, instance, tests and zopepy.

Note: Using global `eggs` section for this is not recommended.
