### PR TITLE
Show how my zope2instance changes can simplify core.cfg

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -7,12 +7,7 @@ extends =
     tests.cfg
 
 parts +=
-    wsgi.py
-    uwsgi_ini
-    nginx_uwsgi_conf
-    waitress_ini
-    wsgi
-    zconsole
+    instance
     zopepy
     packages
     releaser
@@ -57,11 +52,10 @@ plone-user =
     admin:admin
 
 
-[wsgi.py]
+[instance]
 recipe = plone.recipe.zope2instance
 user = ${buildout:plone-user}
 wsgi = on
-control-script = wsgi.py
 eggs =
     Plone
     ${buildout:custom-eggs}
@@ -71,49 +65,6 @@ eggs =
 # shared-blob = on
 environment-vars =
     zope_i18n_compile_mo_files true
-
-
-[uwsgi_ini]
-recipe = collective.recipe.template[genshi]:genshi
-input = ${buildout:template-directory}/uwsgi.ini
-output = ${buildout:config-directory}/uwsgi.ini
-num-threads = 2
-http-socket = 0.0.0.0:8080
-socket = 127.0.0.1:8081
-
-
-[nginx_uwsgi_conf]
-recipe = collective.recipe.template[genshi]:genshi
-input = ${buildout:template-directory}/nginx-uwsgi.conf
-output = ${buildout:config-directory}/nginx-uwsgi.conf
-
-
-[waitress_ini]
-recipe = collective.recipe.template[genshi]:genshi
-input = ${buildout:template-directory}/waitress.ini
-output = ${buildout:config-directory}/waitress.ini
-listen = 0.0.0.0:6543
-
-
-[wsgi]
-recipe = collective.recipe.template[genshi]:genshi
-inline =
-    #!/bin/sh
-    ${buildout:bin-directory}/wsgi.py ${buildout:directory}/etc/waitress.ini
-output = ${buildout:bin-directory}/wsgi
-mode = 755
-
-
-[zconsole]
-recipe = collective.recipe.template[genshi]:genshi
-inline =
-    #!/bin/sh
-    MODE=$$1
-    shift
-    ${buildout:bin-directory}/zopepy -m Zope2.utilities.zconsole $$MODE ${buildout:parts-directory}/wsgi.py/etc/zope.conf $$*
-output = ${buildout:bin-directory}/zconsole
-mode = 755
-
 
 [zopepy]
 recipe = zc.recipe.egg

--- a/sources.cfg
+++ b/sources.cfg
@@ -109,7 +109,7 @@ plone.protect                       = git ${remotes:plone}/plone.protect.git pus
 plone.recipe.alltests               = git ${remotes:plone}/plone.recipe.alltests.git pushurl=${remotes:plone_push}/plone.recipe.alltests.git branch=master
 plone.recipe.precompiler            = git ${remotes:plone}/plone.recipe.precompiler.git pushurl=${remotes:plone_push}/plone.recipe.precompiler.git branch=master
 plone.recipe.zeoserver              = git ${remotes:plone}/plone.recipe.zeoserver.git pushurl=${remotes:plone_push}/plone.recipe.zeoserver.git branch=master
-plone.recipe.zope2instance          = git ${remotes:plone}/plone.recipe.zope2instance.git pushurl=${remotes:plone_push}/plone.recipe.zope2instance.git branch=master
+plone.recipe.zope2instance          = git ${remotes:plone}/plone.recipe.zope2instance.git pushurl=${remotes:plone_push}/plone.recipe.zope2instance.git branch=wsgi-instance-script
 plone.rest                          = git ${remotes:plone}/plone.rest.git pushurl=${remotes:plone_push}/plone.rest.git branch=master
 plone.restapi                       = git ${remotes:plone}/plone.restapi.git pushurl=${remotes:plone_push}/plone.restapi.git branch=master
 plone.registry                      = git ${remotes:plone}/plone.registry.git pushurl=${remotes:plone_push}/plone.registry.git branch=master

--- a/sources.cfg
+++ b/sources.cfg
@@ -109,7 +109,7 @@ plone.protect                       = git ${remotes:plone}/plone.protect.git pus
 plone.recipe.alltests               = git ${remotes:plone}/plone.recipe.alltests.git pushurl=${remotes:plone_push}/plone.recipe.alltests.git branch=master
 plone.recipe.precompiler            = git ${remotes:plone}/plone.recipe.precompiler.git pushurl=${remotes:plone_push}/plone.recipe.precompiler.git branch=master
 plone.recipe.zeoserver              = git ${remotes:plone}/plone.recipe.zeoserver.git pushurl=${remotes:plone_push}/plone.recipe.zeoserver.git branch=master
-plone.recipe.zope2instance          = git ${remotes:plone}/plone.recipe.zope2instance.git pushurl=${remotes:plone_push}/plone.recipe.zope2instance.git branch=wsgi-instance-script
+plone.recipe.zope2instance          = git ${remotes:plone}/plone.recipe.zope2instance.git pushurl=${remotes:plone_push}/plone.recipe.zope2instance.git branch=master
 plone.rest                          = git ${remotes:plone}/plone.rest.git pushurl=${remotes:plone_push}/plone.rest.git branch=master
 plone.restapi                       = git ${remotes:plone}/plone.restapi.git pushurl=${remotes:plone_push}/plone.restapi.git branch=master
 plone.registry                      = git ${remotes:plone}/plone.registry.git pushurl=${remotes:plone_push}/plone.registry.git branch=master


### PR DESCRIPTION
This is to demonstrate how my wsgi-enabled instance script in plone/plone.recipe.zope2instance#52 can simplify a Plone 5.2 + Python 3 buildout. It shouldn't be merged until that PR is merged.