### PR TITLE
add plone_app_locales for i18n searches

### DIFF
--- a/experimental/i18n.cfg
+++ b/experimental/i18n.cfg
@@ -55,6 +55,7 @@ plone =
     plone.app.iterate
     plone.app.layout
     plone.app.linkintegrity
+    plone.app.locales
     plone.app.lockingbehavior
     plone.app.multilingual
     plone.app.portlets


### PR DESCRIPTION
Because some msgid was removed from 5.1 to 5.2, to ensure backward compatibility, I place all removed msgid in Python file (backward_compat_51.py) on plone.app.locales (the checkin follow on a branch called new_msgid_5.2).
For this, we must search also in plone.app.locales
Thank's