### PR TITLE
Do not allow packages without a pinned version

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -32,6 +32,7 @@ extensions =
     mr.developer
 
 show-picked-versions = true
+allow-picked-versions = false
 
 # define a template directory here in order to override it later in custom
 template-directory = ${buildout:directory}/templates


### PR DESCRIPTION
New packages are always welcome,
but knowing why they got introduced, maybe by mistake, 
could help identify and discuss the introduction of third party dependencies.