### PR TITLE
Fixed extensions on Python 2.7.

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -26,7 +26,7 @@ allow-hosts =
 
 find-links += http://dist.plone.org/thirdparty/
 
-extensions +=
+extensions =
 # Keep mr.developer as last one, because some jenkins scripts look for
 # this and add a git-clone-depth after it.
     mr.developer


### PR DESCRIPTION
core.cfg had `extensions += mr.developer`
and for Python 2.7 this was overwritten to `extensions += plone.versioncheck`.
This first one should have been simply `extensions`.

Fixes problem reported by me [here](https://github.com/plone/buildout.coredev/pull/556#issuecomment-439144613).

This causes a [Jenkins test failure](https://jenkins.plone.org/job/plone-5.2-python-2.7/2348/) on Python 2.7 only, because the failing `plone.app.z3cform` test needs a checkout of `plone.app.widgets`. On Python 3 the checkout is done, but on Python 2 the `mr.developer` extension is not installed.