### PR TITLE
Pin persistent anyway, as it is a z3c.form test-only dependency. [5.0]

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -70,6 +70,10 @@ mock = 1.0.1
 pycodestyle = 2.3.1
 zope.testbrowser = 3.11.1
 zope.testrunner = 4.4.4
+# persistent is not compatible with ZODB 3.10 which we are using
+# If you have a dependency somewher on persistent, you must
+# try to get rid of it.  But z3c.form has it in the test dependencies.
+persistent = 4.2.4.2
 
 # Robot Testing
 plone.app.robotframework = 1.3.1
@@ -136,11 +140,6 @@ argparse = 1.4.0
 # pinned in zope tookit. so update to latest legacy package, which is
 # a simple compatibility layer that installs Setuptools 0.7+
 distribute = 0.7.3
-
-# Persistent is not compatible with ZODB 3.10 which we are using
-# If you have a dependency somewher on persistent, you must
-# try to get rid of it.
-# persistent = 4.0.6
 
 ###############
 # Plone release


### PR DESCRIPTION
We did the same for coredev 5.1 in 2016, see
https://github.com/plone/buildout.coredev/pull/204
Use the same version pin as on current 5.1.