### PR TITLE
Fix parts for Python 2.7

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -6,7 +6,7 @@ extends =
     versions.cfg
     tests.cfg
 
-parts +=
+parts =
     instance
     zopepy
     packages
@@ -53,10 +53,15 @@ plone-user =
     admin:admin
 
 [buildout:python27]
-parts +=
+parts =
     instance
     instance-archetypes
     ploneversioncheck
+    zopepy
+    packages
+    releaser
+    z3c_checkversions
+    dependencies
 
 extensions +=
     plone.versioncheck


### PR DESCRIPTION
packages, zopepy and other parts were missing in py2. Fixes https://github.com/plone/Products.CMFPlone/issues/2711