### PR TITLE
Always run virtualenv with python 2.7 in bootstrap.sh for 5.1

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-virtualenv --clear .
+virtualenv --clear -p python2.7 .
 ./bin/pip install -r requirements.txt
 ./bin/buildout $*


### PR DESCRIPTION
The latest virtualenv by default installs a python 3.x/3.7 environment without -p option.
Theoretically python2 would be enough, but anything below 2.7 is not supported anyway.