### PR TITLE
Let flake8 ignore W503: Line break occurred before a binary operator.

### DIFF
--- a/experimental/qa.cfg
+++ b/experimental/qa.cfg
@@ -17,6 +17,12 @@ pre-commit-hook = False
 jenkins = True
 check-manifest = True
 clean-lines = True
+# With line breaks and binary operators you will always hit one of these:
+# W503: Line break occurred before a binary operator
+# W504: Line break occurred after a binary operator
+# The pep8 guidelines were changed to recommend the line break before.
+# See https://lintlyci.github.io/Flake8Rules/rules/W503.html
+flake8-ignore = W503
 # keep this list in sync with what plone.recipe.codeanalysis defines
 # on its [recommended] extra, see:
 # https://github.com/plone/plone.recipe.codeanalysis/blob/master/setup.py


### PR DESCRIPTION
With line breaks and binary operators you will *always* hit either this warning:

  W503: Line break occurred before a binary operator

or this warning:

  W504: Line break occurred after a binary operator

The pep8 guidelines were changed to recommend the line break before.
See https://lintlyci.github.io/Flake8Rules/rules/W503.html

So we ignore W503.

See the code analysis report that I just got for [`plone.api`](https://github.com/plone/plone.api/commit/b5eaefab97162e8a712d39a1b0c95ef98043c653).