### PR TITLE
Update to Zope 4.1

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -2,7 +2,7 @@
 # This file is part of buildout.coredev repository: https://github.com/plone/buildout.coredev
 # The plone release team is responsible for it,
 # if you have suggestions, please open an issue at: https://github.com/plone/buildout.coredev/issues
-extends = https://raw.githubusercontent.com/zopefoundation/Zope/4.0b10/versions.cfg
+extends = https://raw.githubusercontent.com/zopefoundation/Zope/4.1/versions.cfg
 
 [versions]
 ##############################################################################
@@ -19,7 +19,7 @@ click = 7.0
 collective.recipe.omelette = 0.16
 collective.recipe.template = 2.1
 freezegun = 0.3.11
-Genshi = 0.7.2
+Genshi = 0.7.3
 incremental = 17.5.0
 mr.developer = 2.0.0
 plone.recipe.alltests = 1.5.1
@@ -36,7 +36,7 @@ tqdm = 4.31.1
 twine = 1.13.0
 z3c.checkversions = 1.1
 z3c.template = 3.1.0
-zest.releaser = 6.18.2
+zest.releaser = 6.19.0
 zestreleaser.towncrier = 1.2.0
 
 # testing
@@ -66,11 +66,11 @@ msgpack = 0.6.1
 # Zope world dependencies
 
 # Plone dependencies on other Zope packages not part of the Zope release
-Products.ExternalMethod = 4.2
-Products.MailHost = 4.5
-Products.PythonScripts = 4.6
+Products.ExternalMethod = 4.3
+Products.MailHost = 4.7
+Products.PythonScripts = 4.7
 Products.StandardCacheManagers = 4.0.2
-tempstorage = 4.0.1
+tempstorage = 5.0
 zc.relation = 1.1.post2
 zc.sourcefactory = 1.1
 ZODB3 = 3.11.0
@@ -195,7 +195,7 @@ plone.registry                        = 1.1.5
 plone.reload                          = 3.0.0
 plone.resource                        = 2.1.1
 plone.rest                            = 1.4.0
-plone.restapi                         = 4.0.0
+plone.restapi                         = 4.1.2
 plone.resourceeditor                  = 3.0.0
 plone.rfc822                          = 2.0.1
 plone.scale                           = 3.0.3
@@ -213,7 +213,7 @@ plone.transformchain                  = 2.0.1
 plone.uuid                            = 1.0.5
 plone.z3cform                         = 1.1.0
 plonetheme.barceloneta                = 2.1.2
-Products.CMFCore                      = 2.4.0b8
+Products.CMFCore                      = 2.4.0
 Products.CMFDiffTool                  = 3.2.2
 Products.CMFDynamicViewFTI            = 6.0.1
 Products.CMFEditions                  = 3.3.2
@@ -227,12 +227,12 @@ Products.DateRecurringIndex           = 3.0.0
 Products.DCWorkflow                   = 2.4.0b2
 Products.ExtendedPathIndex            = 3.4.2
 Products.ExternalEditor               = 3.0
-Products.GenericSetup                 = 2.0b6
+Products.GenericSetup                 = 2.0
 Products.MimetypesRegistry            = 2.1.5
 Products.PloneLanguageTool            = 3.2.9
 Products.PlonePAS                     = 6.0.2
 Products.PloneTestCase                = 0.9.18
-Products.PluggableAuthService         = 2.0b6
+Products.PluggableAuthService         = 2.0
 Products.PluginRegistry               = 1.7
 Products.PortalTransforms             = 3.1.7
 Products.SecureMailHost               = 1.1.2
@@ -241,7 +241,7 @@ Products.SiteErrorLog                 = 5.3
 Products.TemporaryFolder              = 5.3
 Products.statusmessages               = 5.0.4
 Products.ZopeVersionControl           = 1.1.4
-Products.ZSQLMethods                  = 3.0.6
+Products.ZSQLMethods                  = 3.0.7
 sourcecodegen                         = 0.6.14
 z3c.autoinclude                       = 0.3.9
 z3c.caching                           = 2.1


### PR DESCRIPTION
Replaces https://github.com/plone/buildout.coredev/pull/586 and fixes https://github.com/zopefoundation/Zope/issues/397 for Plone