### PR TITLE
On Python 2.7, pin keyring back to compatible version.

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -202,6 +202,9 @@ jeepney = 0.4
 asn1crypto = 0.24.0
 cryptography = 2.7
 
+[versions:python27]
+keyring = 18.0.0
+
 [versionannotations]
 # keep this alphabetical please
 

--- a/tests.cfg
+++ b/tests.cfg
@@ -203,7 +203,7 @@ asn1crypto = 0.24.0
 cryptography = 2.7
 
 [versions:python27]
-keyring = 18.0.0
+keyring = 4.1.1
 
 [versionannotations]
 # keep this alphabetical please


### PR DESCRIPTION
This is the last release that supports Python 2.7.
It is used by parts of plone.releaser.
Fixes part of https://github.com/plone/plone.releaser/issues/25

Initially I had committed this directly to the 5.2 branch, which was fine locally, but it failed on Jenkins.  So I reverted the commit, and am now trying it in a PR.

See https://jenkins.plone.org/job/plone-5.2-python-2.7/273/console
The error is:
    
```
Installing releaser.
Version and requirements information containing secretstorage:
  [versions] constraint on secretstorage: 3.1.1
  Requirement of keyring: secretstorage<3
While:
  Installing releaser.
Error: The requirement ('secretstorage<3') is not allowed by your [versions] constraint (3.1.1)
```
    
But that is strange, because secretstorage is not pinned at all in our versions.
It does not show up in `bin/buildout annotate`.
Locally it does not end up in `bin/fullrelease`.

Note that coredev 5.1 uses keyring 4.1.1, so maybe we should use that.