### PR TITLE
Use Zope 4.1.2.

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -20,8 +20,6 @@ auto-checkout =
     Products.CMFCore
     Products.GenericSetup
     Products.PluginRegistry
-# Temporarily commented out, see https://github.com/plone/buildout.coredev/issues/602
-#    Products.PythonScripts
     Products.Sessions
     plone.dexterity
     plone.folder

--- a/versions.cfg
+++ b/versions.cfg
@@ -2,7 +2,7 @@
 # This file is part of buildout.coredev repository: https://github.com/plone/buildout.coredev
 # The plone release team is responsible for it,
 # if you have suggestions, please open an issue at: https://github.com/plone/buildout.coredev/issues
-extends = https://raw.githubusercontent.com/zopefoundation/Zope/4.1.1/versions.cfg
+extends = https://raw.githubusercontent.com/zopefoundation/Zope/4.1.2/versions.cfg
 
 [versions]
 ##############################################################################
@@ -69,7 +69,7 @@ msgpack = 0.6.1
 # Plone dependencies on other Zope packages not part of the Zope release
 Products.ExternalMethod = 4.3
 Products.MailHost = 4.7
-Products.PythonScripts = 4.7
+Products.PythonScripts = 4.8
 Products.StandardCacheManagers = 4.0.2
 tempstorage = 5.0
 zc.relation = 1.1.post2
@@ -302,6 +302,7 @@ chameleon = 3.6.2
 
 [versions:python27]
 trollius = 2.2.post1
+docutils = 0.14
 
 # BBB only packages (to be removed with Plone 5.3 or 6.0 and in 5.2 on Python 3.6+
 plone.app.controlpanel                = 4.0.0


### PR DESCRIPTION
Fixes version conflict, see https://github.com/plone/buildout.coredev/issues/602