### PR TITLE
generate constraints.txt

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -19,10 +19,16 @@ allow-hosts =
 find-links += http://dist.plone.org/thirdparty/
 
 extensions =
+    buildout.requirements
 # Keep mr.developer as last one, because some jenkins scripts look for
 # this and add a git-clone-depth after it.
     mr.developer
 
+# write a constraints file
+dump-requirements-file = ${buildout:directory}/constraints.txt
+overwrite-requirements-file = true
+
+# require picked versions
 show-picked-versions = true
 allow-picked-versions = false
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -14,6 +14,7 @@ setuptools = 41.0.1
 zc.buildout = 2.13.2
 
 # recipes and extensions
+buildout.requirements = 0.2.2
 cachecontrol = 0.12.5
 click = 7.0
 collective.recipe.omelette = 0.16


### PR DESCRIPTION
For later use with pip like `pip install -c constraints.txt Plone Paste` 

After above works, for next release it would be great to have it released to dist.plone.org, 
@esteele What do you think?

This can be merged right away, it doe not hurt now.