### PR TITLE
Upgrade to Zope2 2.13.29 and Products.ZCatalog 2.13.30. [4.3.x]

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -8,13 +8,12 @@ extends = http://dist.plone.org/versions/zopetoolkit-1-0-8-zopeapp-versions.cfg
 [versions]
 # Zope overrides
 docutils = 0.12
-Zope2 = 2.13.28
+Zope2 = 2.13.29
+Products.ZCatalog = 2.13.30
 # Get support for @security decorators
 AccessControl = 3.0.11
 # More memory efficient version, Trac #13101
 DateTime = 3.0.3
-# DocumentTemplate XSS fix:
-DocumentTemplate = 2.13.4
 # Products.BTreeFolder2 2.13.4 causes a regression
 Products.BTreeFolder2 = 2.13.3
 # Override until ztk is updated


### PR DESCRIPTION
Zope2 was at .28, and ZCatalog was at .29 (from http://dist.plone.org/versions/zope-2-13-27-versions.cfg)
See also https://github.com/plone/buildout.coredev/issues/462

Removed the DocumentTemplate pin, because it is the same as upstream for these three Zope2 versions.

See the [Zope2 changes](https://github.com/zopefoundation/Zope/blob/2.13.29/doc/CHANGES.rst) and the [ZCatalog change](https://github.com/zopefoundation/Products.ZCatalog/commit/24b78143772a6876f06fc7bef36cee63f8bf9aea). The changes seem safe.