### PR TITLE
Revert Products.CMFCore to 2.2.10. [4.3]

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -144,7 +144,9 @@ Products.ATContentTypes             = git ${remotes:plone}/Products.ATContentTyp
 Products.ATReferenceBrowserWidget   = git ${remotes:plone}/Products.ATReferenceBrowserWidget.git pushurl=${remotes:plone_push}/Products.ATReferenceBrowserWidget.git branch=master
 Products.CMFActionIcons             = git ${remotes:zope}/Products.CMFActionIcons.git pushurl=${remotes:zope_push}/Products.CMFActionIcons.git branch=2.1.x
 Products.CMFCalendar                = git ${remotes:zope}/Products.CMFCalendar.git pushurl=${remotes:zope_push}/Products.CMFCalendar.git branch=2.2
-Products.CMFCore                    = git ${remotes:zope}/Products.CMFCore.git pushurl=${remotes:zope_push}/Products.CMFCore.git branch=2.2
+# Note: CMFCore must forever remain on 2.2.10.
+# See https://github.com/plone/Products.CMFPlone/issues/2042
+Products.CMFCore                    = git ${remotes:zope}/Products.CMFCore.git pushurl=${remotes:zope_push}/Products.CMFCore.git rev=2.2.10
 Products.CMFDefault                 = git ${remotes:zope}/Products.CMFDefault.git pushurl=${remotes:zope_push}/Products.CMFDefault.git branch=2.2
 Products.CMFDiffTool                = git ${remotes:plone}/Products.CMFDiffTool.git pushurl=${remotes:plone_push}/Products.CMFDiffTool.git branch=2.2.x
 Products.CMFDynamicViewFTI          = git ${remotes:plone}/Products.CMFDynamicViewFTI.git pushurl=${remotes:plone_push}/Products.CMFDynamicViewFTI.git branch=4.x

--- a/versions.cfg
+++ b/versions.cfg
@@ -107,7 +107,9 @@ Products.ATReferenceBrowserWidget     = 3.0
 Products.Archetypes                   = 1.9.20
 Products.CMFActionIcons               = 2.1.3
 Products.CMFCalendar                  = 2.2.3
-Products.CMFCore                      = 2.2.13
+# Note: CMFCore must forever remain on 2.2.10.
+# See https://github.com/plone/Products.CMFPlone/issues/2042
+Products.CMFCore                      = 2.2.10
 Products.CMFDefault                   = 2.2.4
 Products.CMFDiffTool                  = 2.2.1
 Products.CMFDynamicViewFTI            = 4.1.8


### PR DESCRIPTION
In 2.2.11 collective.indexing was merged, so we never want that in Plone 4.3 or 5.0.
That merge should never have happened on the 2.2 branch, but that was in 2017, so we can't do anything about that.

In 2017 this already gave errors in Plone 5.0: https://github.com/plone/Products.CMFPlone/issues/2042
Now with 2.2.13, Jenkins is failing on 4.3: https://jenkins.plone.org/job/plone-4.3-python-2.7/26/

I worried that this may have gotten in last moment for Plone 4.3.19, but this is not the case.  It has the correct 2.2.10. Phew!

Note: we don't have any `versionannotations` section in the buildout, like we have on 5.x. I am not sure if that would have helped here.