### PR TITLE
Use CHAMELEON_CACHE env var in bin/test.

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -210,6 +210,8 @@ keyring = 4.1.1
 
 [environment]
 BUILDOUT_DIR = ${buildout:directory}
+# This dir must exist.  Recent plone.recipe.zope2instance normally creates it:
+CHAMELEON_CACHE = ${buildout:directory}/var/cache
 ROBOTSUITE_LOGLEVEL = ERROR
 ROBOTSUITE_APPEND_OUTPUT_XML = 1
 zope_i18n_compile_mo_files = true


### PR DESCRIPTION
This should speed the tests up.
I hope that the directory is automatically created on Jenkins by the instance part.
See https://github.com/plone/Products.CMFPlone/issues/2898