### PR TITLE
Fix docutils version constraint.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -217,7 +217,7 @@ plone.transformchain                  = 2.0.1
 plone.uuid                            = 1.0.5
 plone.z3cform                         = 1.1.1
 plonetheme.barceloneta                = 2.1.6
-Products.CMFCore                      = 2.4.1
+Products.CMFCore                      = 2.4.2
 Products.CMFDiffTool                  = 3.3.0
 Products.CMFDynamicViewFTI            = 6.0.2
 Products.CMFEditions                  = 3.3.3
@@ -294,7 +294,7 @@ chameleon = 3.6.2
 
 [versions:python27]
 trollius = 2.2.post1
-docutils = 0.14
+docutils = 0.15.2
 
 # BBB only packages (to be removed with Plone 5.3 or 6.0 and in 5.2 on Python 3.6+
 plone.app.controlpanel                = 4.0.0


### PR DESCRIPTION
@esteele @mauritsvanrees 

Fixes:
```
Version and requirements information containing docutils:
  [versions] constraint on docutils: 0.14
  Requirement of plone.app.theming: docutils
  Requirement of Products.CMFCore: docutils>0.15
  Requirement of Products.CMFCore>=2.1: docutils>0.15
While:
  Installing instance.
Error: The requirement ('docutils>0.15') is not allowed by your [versions] constraint (0.14)
```