### PR TITLE
Update DocumentTemplate and Products.ZSQLMethods for hotfix [4.3]

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -26,6 +26,8 @@ zope.pagetemplate = 3.6.3
 zope.formlib = 4.3.0
 # Several tests rely on an old-style pytz release:
 pytz = 2013b
+# PloneHotfix20200121:
+DocumentTemplate = 2.13.5
 
 # Build tools
 buildout.dumppickedversions = 0.5
@@ -140,7 +142,7 @@ Products.ResourceRegistries           = 2.2.13
 Products.SecureMailHost               = 1.1.2
 Products.TinyMCE                      = 1.3.29
 Products.ZopeVersionControl           = 1.1.3
-Products.ZSQLMethods                  = 2.13.5
+Products.ZSQLMethods                  = 2.13.6
 Products.i18ntestcase                 = 1.4.0
 Products.statusmessages               = 4.1.2
 Products.validation                   = 2.0.2


### PR DESCRIPTION
Use versions of DocumentTemplate and Products.ZSQLMethods where PloneHotfix20200121 has been integrated.