### PR TITLE
Update DocumentTemplate and Products.ZSQLMethods for hotfix. [5.1]

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -15,6 +15,8 @@ ExtensionClass = 4.3.0
 Acquisition = 4.4.2
 # More memory efficient version, Trac #13101
 DateTime = 4.2
+# PloneHotfix20200121:
+DocumentTemplate = 2.13.6
 # other updates
 Products.BTreeFolder2 = 2.14.0
 Missing = 3.2
@@ -316,7 +318,7 @@ Products.ResourceRegistries           = 3.0.7
 Products.SecureMailHost               = 1.1.2
 Products.statusmessages               = 5.0.4
 Products.ZopeVersionControl           = 1.1.4
-Products.ZSQLMethods                  = 2.13.5
+Products.ZSQLMethods                  = 2.13.6
 sourcecodegen                         = 0.6.14
 z3c.autoinclude                       = 0.3.9
 z3c.caching                           = 2.0a1


### PR DESCRIPTION
Use versions of DocumentTemplate and Products.ZSQLMethods where PloneHotfix20200121 has been integrated.