### PR TITLE
Update DocumentTemplate and Products.ZSQLMethods for hotfix. [5.2]

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -66,6 +66,8 @@ msgpack = 0.6.2
 
 ##############################################################################
 # Zope world dependencies
+# PloneHotfix20200121:
+DocumentTemplate = 3.1
 
 # Plone dependencies on other Zope packages not part of the Zope release
 Products.ExternalMethod = 4.3
@@ -248,7 +250,7 @@ Products.SiteErrorLog                 = 5.3
 Products.TemporaryFolder              = 5.3
 Products.statusmessages               = 5.0.4
 Products.ZopeVersionControl           = 1.1.4
-Products.ZSQLMethods                  = 3.0.9
+Products.ZSQLMethods                  = 3.0.11
 sourcecodegen                         = 0.6.14
 z3c.autoinclude                       = 0.3.9
 z3c.caching                           = 2.2


### PR DESCRIPTION
Use versions of DocumentTemplate and Products.ZSQLMethods where PloneHotfix20200121 has been integrated.