### PR TITLE
Set ROBOTSUITE_RETRY_COUNT = 3 in the bin/test environment.

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -214,6 +214,7 @@ BUILDOUT_DIR = ${buildout:directory}
 CHAMELEON_CACHE = ${buildout:directory}/var/cache
 ROBOTSUITE_LOGLEVEL = ERROR
 ROBOTSUITE_APPEND_OUTPUT_XML = 1
+ROBOTSUITE_RETRY_COUNT = 3
 zope_i18n_compile_mo_files = true
 
 [test]


### PR DESCRIPTION
This is a new feature from robotsuite.
Let's see how well this works.
It may not be right for all robot tests.
It can also be added to individual RobotSuiteTests with retry_count=X.
Note: with a retry count of 3, the test is tried 4 times.  One try, three retries.