### PR TITLE
DocumentTemplate = 3.2.2.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -67,7 +67,7 @@ msgpack = 0.6.2
 ##############################################################################
 # Zope world dependencies
 # PloneHotfix20200121:
-DocumentTemplate = 3.1
+DocumentTemplate = 3.2.2
 
 # Plone dependencies on other Zope packages not part of the Zope release
 Products.ExternalMethod = 4.3


### PR DESCRIPTION
For PloneHotfix20200121.
We already updated it in PR #633, but there is a newer version with related (and unrelated) fixes.