### PR TITLE
Do not generate dependent releaser scripts on Python 3.6.

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -15,6 +15,7 @@ auto-checkout =
     five.intid
     plone.app.discussion
     plone.app.redirector
+    plone.app.robotframework
     plone.app.theming
     plone.app.uuid
     plone.dexterity

--- a/core.cfg
+++ b/core.cfg
@@ -134,6 +134,12 @@ eggs =
     zest.pocompile
 
 
+[releaser:python36]
+# Jenkins node 4 has trouble with Python 3.6 and non-ascii.
+# You see this when generating bin/rst2html5.py, among probably others.
+dependent-scripts = false
+
+
 [z3c_checkversions]
 # run this via bin/checkversions -l 2 versions.cfg
 recipe = zc.recipe.egg

--- a/sources.cfg
+++ b/sources.cfg
@@ -68,7 +68,7 @@ plone.app.redirector                = git ${remotes:plone}/plone.app.redirector.
 plone.app.referenceablebehavior     = git ${remotes:plone}/plone.app.referenceablebehavior.git pushurl=${remotes:plone_push}/plone.app.referenceablebehavior.git branch=master
 plone.app.registry                  = git ${remotes:plone}/plone.app.registry.git pushurl=${remotes:plone_push}/plone.app.registry.git branch=master
 plone.app.relationfield             = git ${remotes:plone}/plone.app.relationfield.git pushurl=${remotes:plone_push}/plone.app.relationfield.git branch=master
-plone.app.robotframework            = git ${remotes:plone}/plone.app.robotframework.git pushurl=${remotes:plone_push}/plone.app.robotframework.git branch=master
+plone.app.robotframework            = git ${remotes:plone}/plone.app.robotframework.git pushurl=${remotes:plone_push}/plone.app.robotframework.git branch=maurits/jenkins-node-4-py36
 plone.app.testing                   = git ${remotes:plone}/plone.app.testing.git pushurl=${remotes:plone_push}/plone.app.testing.git branch=master
 plone.app.textfield                 = git ${remotes:plone}/plone.app.textfield.git pushurl=${remotes:plone_push}/plone.app.textfield.git branch=master
 plone.app.theming                   = git ${remotes:plone}/plone.app.theming.git pushurl=${remotes:plone_push}/plone.app.theming.git branch=master
@@ -110,7 +110,7 @@ plone.recipe.precompiler            = git ${remotes:plone}/plone.recipe.precompi
 plone.recipe.zeoserver              = git ${remotes:plone}/plone.recipe.zeoserver.git pushurl=${remotes:plone_push}/plone.recipe.zeoserver.git branch=master
 plone.recipe.zope2instance          = git ${remotes:plone}/plone.recipe.zope2instance.git pushurl=${remotes:plone_push}/plone.recipe.zope2instance.git branch=master
 plone.rest                          = git ${remotes:plone}/plone.rest.git pushurl=${remotes:plone_push}/plone.rest.git branch=master
-plone.restapi                       = git ${remotes:plone}/plone.restapi.git pushurl=${remotes:plone_push}/plone.restapi.git branch=master
+plone.restapi                       = git ${remotes:plone}/plone.restapi.git pushurl=${remotes:plone_push}/plone.restapi.git branch=maurits/jenkins-node-4-py36
 plone.registry                      = git ${remotes:plone}/plone.registry.git pushurl=${remotes:plone_push}/plone.registry.git branch=master
 plone.releaser                      = git ${remotes:plone}/plone.releaser.git pushurl=${remotes:plone_push}/plone.releaser.git branch=master
 plone.reload                        = git ${remotes:plone}/plone.reload.git pushurl=${remotes:plone_push}/plone.reload.git branch=master


### PR DESCRIPTION
Needed to fix the hopefully last problems on Jenkins node 4 with Python 3.6, which seems to have no locale setting.
See https://github.com/plone/buildout.coredev/issues/642#issuecomment-597008272

Sample traceback (local):

```
While:
  Installing releaser.
Traceback (most recent call last):
  File "/Users/maurits/community/plone-coredev/py3/lib/python3.6/site-packages/zc/buildout/buildout.py", line 2174, in main
    getattr(buildout, command)(args)
  File "/Users/maurits/community/plone-coredev/py3/lib/python3.6/site-packages/zc/buildout/buildout.py", line 817, in install
    installed_files = self[part]._call(recipe.install)
  File "/Users/maurits/community/plone-coredev/py3/lib/python3.6/site-packages/zc/buildout/buildout.py", line 1603, in _call
    return f()
  File "/Users/maurits/shared-eggs/cp36m/zc.recipe.egg-2.0.7-py3.6.egg/zc/recipe/egg/egg.py", line 263, in install
    relative_paths=self._relative_paths,
  File "/Users/maurits/community/plone-coredev/py3/lib/python3.6/site-packages/zc/buildout/easy_install.py", line 1219, in scripts
    _distutils_script(spath, sname, contents, initialization, rpsetup)
  File "/Users/maurits/community/plone-coredev/py3/lib/python3.6/site-packages/zc/buildout/easy_install.py", line 1346, in _distutils_script
    return _create_script(contents, dest)
  File "/Users/maurits/community/plone-coredev/py3/lib/python3.6/site-packages/zc/buildout/easy_install.py", line 1384, in _create_script
    f.write(contents)
UnicodeEncodeError: 'ascii' codec can't encode character '\xa9' in position 96: ordinal not in range(128)
```

This is while generating the `bin/rst2html5.py` script, which fails because it contains this text:

    Copyright: © 2015 Günter Milde.

Note: the result on Python 3.6 may not be good.  It can be that `bin/fullrelease` is created but it cannot function properly because `bin/towncrier` and `bin/twine` are missing, although I think we may be calling them with Python imports instead of invoking them in a subprocess.  So it could be okay.

Anyway, when you don't have a locale, the buildout will now finally finish, but not everything works.  For example, during prerelease I then get an error via towncrier/click:

```
Traceback (most recent call last):
File "/Users/maurits/community/plone-coredev/py3/bin/towncrier", line 67, in <module>
sys.exit(towncrier._main())
File "/Users/maurits/shared-eggs/cp36m/Click-7.0-py3.6.egg/click/core.py", line 764, in __call__
return self.main(*args, **kwargs)
File "/Users/maurits/shared-eggs/cp36m/Click-7.0-py3.6.egg/click/core.py", line 696, in main
_verify_python3_env()
File "/Users/maurits/shared-eggs/cp36m/Click-7.0-py3.6.egg/click/_unicodefun.py", line 124, in _verify_python3_env
' mitigation steps.' + extra
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment. Consult https://click.palletsprojects.com/en/7.x/python3/ for mitigation steps.
```

This points to an interesting page: https://click.palletsprojects.com/en/7.x/python3/
It also says that from Python 3.7 onwards this is no problem anymore, even though you should still configure your locale correctly.