### PR TITLE
Use python3 and not hardcoded python3.6 in bootstrap_py3

### DIFF
--- a/bootstrap-py3.sh
+++ b/bootstrap-py3.sh
@@ -1,5 +1,5 @@
 #/bin/sh
-`which python3.6` -m venv .
+`which python3` -m venv .
 ./bin/pip install -r requirements.txt
 ./bin/buildout $*
 echo "run plone with: ./bin/instance fg"


### PR DESCRIPTION
'which python3.6` is hardcoded in the boostrap_py3.sh script.

* we could use 3.7 or 3.8 but that might break
* we could be 'smart' and first try to detect 3.7 and then fall back to 3.6
* Is Python 3.8 already supported?
* lets stick to searching for python3, as the script is named for now

pros/cons?

(won't start a CI build until it is clear which python3 to pick)