### PR TITLE
Moved Products.validation pin and test-eggs to run on Python 3 as well.

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -113,6 +113,7 @@ test-eggs =
     Products.PluginRegistry
     Products.PortalTransforms
     Products.statusmessages
+    Products.validation
     Products.ZopeVersionControl
     repoze.xmliter
     ${buildout:custom-eggs}
@@ -131,7 +132,6 @@ test-eggs +=
     Products.ATContentTypes [test]
     Products.contentmigration
     Products.Marshall
-    Products.validation
 
 [versions]
 # egg versions that are not part of the release, but should still be pinned

--- a/versions.cfg
+++ b/versions.cfg
@@ -248,6 +248,7 @@ Products.Sessions                     = 4.6
 Products.SiteErrorLog                 = 5.4
 Products.TemporaryFolder              = 5.3
 Products.statusmessages               = 5.0.4
+Products.validation                   = 2.1.1
 Products.ZopeVersionControl           = 2.0.0
 Products.ZSQLMethods                  = 3.0.13
 sourcecodegen                         = 0.6.14
@@ -315,7 +316,6 @@ Products.Archetypes                   = 1.16.1
 Products.ATContentTypes               = 3.0.2
 Products.Marshall                     = 2.4.0
 Products.TinyMCE                      = 1.4.3
-Products.validation                   = 2.1.1
 
 # Ecosystem
 # Archetypes related


### PR DESCRIPTION
In core, it is only used by Archetypes, so it will not end up in bin/instance.
But the dexterity add-on collective.easyform depends on it for its validators, for better or worse.
So would be good to check it on Python 3.

Locally with Python 3.6 its tests pass.