### PR TITLE
Extend Zope 2.13.30 versions file

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -163,7 +163,6 @@ launchpadlib = 1.10.5
 lazr.authentication = 0.1.3
 lazr.restfulclient = 0.13.5
 lazr.uri = 1.0.3
-linecache2 = 1.0.0
 lockfile = 0.12.2
 MarkupSafe = 1.0
 msgpack-python = 0.4.8
@@ -186,23 +185,12 @@ requests-toolbelt = 0.8.0
 SecretStorage = 2.3.1
 smmap2 = 2.0.3
 testresources = 2.0.1
-traceback2 = 1.4.0
-unittest2 = 1.1.0
 wadllib = 1.3.2
 watchdog = 0.8.3
 webencodings = 0.5.1
 wheel = 0.31.1
 zest.pocompile = 1.4
 
-
-[versionannotations]
-# keep this alphabetical please
-linecache2 =
-    unittest2 dependency, to be removed when we get rid of it
-traceback2 =
-    unittest2 dependency, to be removed when we get rid of it
-unittest2 =
-    We should get rid of this one, see https://github.com/plone/Products.CMFPlone/issues/1882
 
 [environment]
 BUILDOUT_DIR = ${buildout:directory}
@@ -448,7 +436,6 @@ exclude =
     ipaddress
     jsonschema
     keyring
-    linecache2
     lxml
     mailinglogger
     manuel
@@ -519,11 +506,9 @@ exclude =
     slimit
     sourcecodegen
     tempstorage
-    traceback2
     transaction
     trollius
     Unidecode
-    unittest2
     waitress
     watchdog
     WebOb

--- a/tests.cfg
+++ b/tests.cfg
@@ -148,7 +148,6 @@ check-manifest = 0.35
 clint = 0.5.1
 cmarkgfm = 0.4.2
 colorama = 0.3.9
-configparser = 3.5.0
 ecdsa = 0.13
 enum34 = 1.1.6
 FormEncode = 1.3.1

--- a/versions.cfg
+++ b/versions.cfg
@@ -2,21 +2,18 @@
 # This file is part of buildout.coredev repository: https://github.com/plone/buildout.coredev
 # The plone release team is responsible for it,
 # if you have suggestions, please open an issue at: https://github.com/plone/buildout.coredev/issues
-extends = http://dist.plone.org/versions/zope-2-13-27-versions.cfg
+extends = https://dist.plone.org/versions/zope-2-13-30-versions.cfg
 
 [versions]
 ################
 # Zope overrides
 docutils = 0.14
-Zope2 = 2.13.29
 # Get support for @security decorators and hotfixes
 AccessControl = 3.0.14
 ExtensionClass = 4.3.0
 Acquisition = 4.4.2
 # More memory efficient version, Trac #13101
 DateTime = 4.2
-# PloneHotfix20200121:
-DocumentTemplate = 2.13.6
 # other updates
 Products.BTreeFolder2 = 2.14.0
 Missing = 3.2


### PR DESCRIPTION
This is a new versions file that I put online yesterday. See issue #462.
This gives us the chance to remove some own version pins. And we were still on Zope2 2.13.29 instead of 30.
Also, we were pinning `unittest2 = 1.1.0` in our `tests.cfg`, but the Zope versions file was extended later, so their version pin 0.5.1 won. So I got rid of our unittest2 pin. It was not pulled in by any of our packages anyway.
