### PR TITLE
Use Zope 4.5.1 (and no other changes)

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -2,7 +2,7 @@
 # This file is part of buildout.coredev repository: https://github.com/plone/buildout.coredev
 # The plone release team is responsible for it,
 # if you have suggestions, please open an issue at: https://github.com/plone/buildout.coredev/issues
-extends = https://zopefoundation.github.io/Zope/releases/4.5/versions.cfg
+extends = https://zopefoundation.github.io/Zope/releases/4.5.1/versions.cfg
 
 [versions]
 ##############################################################################
@@ -30,7 +30,7 @@ plone.versioncheck = 1.7.0
 towncrier = 19.2.0
 twine = 3.1.1
 z3c.template = 3.1.0
-zest.releaser = 6.21.0
+zest.releaser = 6.21.1
 zestreleaser.towncrier = 1.2.0
 pep517 = 0.8.2
 ZopeUndo = 4.3
@@ -78,9 +78,7 @@ zope.keyreference = 4.2.0
 zope.mkzeoinstance = 4.1
 zope.password = 4.3.1
 
-# Newer versions than from the current Zope 4.4.4.  Remove after Zope updates it.
-zodbupdate = 1.5
-zope.sendmail = 5.1
+# Newer versions than from the current Zope 4.5.1.  Remove after Zope updates it.
 
 ##############################################################################
 # External dependencies
@@ -311,3 +309,7 @@ ply =
     3.4 previously pinned for slimit, but calmjs.parse needs 3.6+, though it comes with pre-generated tab files for up to 3.11. See https://github.com/dabeaz/ply/issues/82,
 Unidecode =
     Unidecode 0.04.{2-9} breaks tests
+zope.interface =
+    5.1 gives several test failures
+Products.MailHost =
+    4.10 gives test failures on Python 3 for bytes versus string


### PR DESCRIPTION
Well, use zest.releaser 6.21.1.