### PR TITLE
Updated various versions to bugfixes. [4.3]

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -3,13 +3,11 @@
 # The plone release team is responsible for it,
 # if you have suggestions, please open an issue at: https://github.com/plone/buildout.coredev/issues
 extends = http://dist.plone.org/versions/zopetoolkit-1-0-8-zopeapp-versions.cfg
-          http://dist.plone.org/versions/zope-2-13-27-versions.cfg
+          http://dist.plone.org/versions/zope-2-13-30-versions.cfg
 
 [versions]
 # Zope overrides
 docutils = 0.12
-Zope2 = 2.13.29
-Products.ZCatalog = 2.13.30
 # Get support for @security decorators
 AccessControl = 3.0.11
 # More memory efficient version, Trac #13101
@@ -45,7 +43,7 @@ plone.recipe.zope2instance = 4.4.1
 z3c.coverage = 1.2.0
 z3c.ptcompat = 1.0.1
 z3c.template = 1.4.1
-zope.testrunner = 4.4.4
+zope.testrunner = 4.4.10
 
 # Release
 zest.releaser = 6.13.5
@@ -88,7 +86,7 @@ Jinja2 = 2.7.3
 feedparser = 5.0.1
 future = 0.13.1
 importlib = 1.0.4
-lxml = 4.2.1
+lxml = 4.2.6
 mailinglogger = 3.7.0
 nt-svcutils = 2.13.0
 ordereddict = 1.1
@@ -258,11 +256,11 @@ Products.DateRecurringIndex           = 2.1
 exifread                              = 2.1.2
 collective.elephantvocabulary         = 0.2.5
 collective.js.jqueryui                = 1.10.4
-collective.z3cform.datagridfield      = 1.3.1
+collective.z3cform.datagridfield      = 1.3.3
 five.grok                             = 1.3.2
 five.intid                            = 1.0.3
 grokcore.annotation                   = 1.3
-grokcore.component                    = 2.5
+grokcore.component                    = 2.5.1
 grokcore.formlib                      = 1.9
 grokcore.security                     = 1.6.3
 grokcore.site                         = 1.6.1
@@ -275,7 +273,7 @@ mocker                                = 1.1.1
 plone.app.contenttypes                = 1.1.9
 plone.app.event                       = 1.1.13
 plone.app.intid                       = 1.0.5
-plone.app.lockingbehavior             = 1.0.5
+plone.app.lockingbehavior             = 1.0.7
 plone.app.referenceablebehavior       = 0.7.8
 plone.app.relationfield               = 1.2.3
 plone.app.stagingbehavior             = 0.1
@@ -299,4 +297,4 @@ zope.testbrowser                      = 3.11.1
 mockup                                = 2.7.3
 plone.jsonserializer                  = 0.9.7
 plone.app.tiles                       = 3.1.1
-plone.app.blocks                      = 4.3.0
+plone.app.blocks                      = 4.3.2

--- a/versions.cfg
+++ b/versions.cfg
@@ -43,7 +43,7 @@ plone.recipe.zope2instance = 4.4.1
 z3c.coverage = 1.2.0
 z3c.ptcompat = 1.0.1
 z3c.template = 1.4.1
-zope.testrunner = 4.4.10
+zope.testrunner = 4.4.4
 
 # Release
 zest.releaser = 6.13.5


### PR DESCRIPTION
And upgrade Zope2 to 2.13.30.  I thought I did that a long time ago.

I updated `zope.testrunner` from 4.4.4 to 4.4.10, which means 6 bugfix releases. Should be okay though.

The updated list is adapted from `bin/checkversions -l 2 versions.cfg` (with the extends commented out). I did not apply all bugfix updates, because not all looked safe, and some are known unsafe.