### PR TITLE
Remove CMFQuickInstaller from coredev buildout [6.0]

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -155,7 +155,7 @@ Products.CMFDynamicViewFTI          = git ${remotes:plone}/Products.CMFDynamicVi
 Products.CMFEditions                = git ${remotes:plone}/Products.CMFEditions.git pushurl=${remotes:plone_push}/Products.CMFEditions.git branch=master
 Products.CMFFormController          = git ${remotes:plone}/Products.CMFFormController.git pushurl=${remotes:plone_push}/Products.CMFFormController.git branch=master
 Products.CMFPlacefulWorkflow        = git ${remotes:plone}/Products.CMFPlacefulWorkflow.git pushurl=${remotes:plone_push}/Products.CMFPlacefulWorkflow.git branch=master
-Products.CMFPlone                   = git ${remotes:plone}/Products.CMFPlone.git pushurl=${remotes:plone_push}/Products.CMFPlone.git branch=master
+Products.CMFPlone                   = git ${remotes:plone}/Products.CMFPlone.git pushurl=${remotes:plone_push}/Products.CMFPlone.git branch=maurits/no-qi
 Products.CMFUid                     = git ${remotes:zope}/Products.CMFUid.git pushurl=${remotes:zope_push}/Products.CMFUid.git branch=master
 Products.contentmigration           = git ${remotes:plone}/Products.contentmigration.git pushurl=${remotes:plone_push}/Products.contentmigration.git branch=master
 Products.DateRecurringIndex         = git ${remotes:collective}/Products.DateRecurringIndex.git pushurl=${remotes:collective_push}/Products.DateRecurringIndex.git branch=master

--- a/sources.cfg
+++ b/sources.cfg
@@ -156,7 +156,6 @@ Products.CMFEditions                = git ${remotes:plone}/Products.CMFEditions.
 Products.CMFFormController          = git ${remotes:plone}/Products.CMFFormController.git pushurl=${remotes:plone_push}/Products.CMFFormController.git branch=master
 Products.CMFPlacefulWorkflow        = git ${remotes:plone}/Products.CMFPlacefulWorkflow.git pushurl=${remotes:plone_push}/Products.CMFPlacefulWorkflow.git branch=master
 Products.CMFPlone                   = git ${remotes:plone}/Products.CMFPlone.git pushurl=${remotes:plone_push}/Products.CMFPlone.git branch=master
-Products.CMFQuickInstallerTool      = git ${remotes:plone}/Products.CMFQuickInstallerTool.git pushurl=${remotes:plone_push}/Products.CMFQuickInstallerTool.git branch=master
 Products.CMFUid                     = git ${remotes:zope}/Products.CMFUid.git pushurl=${remotes:zope_push}/Products.CMFUid.git branch=master
 Products.contentmigration           = git ${remotes:plone}/Products.contentmigration.git pushurl=${remotes:plone_push}/Products.contentmigration.git branch=master
 Products.DateRecurringIndex         = git ${remotes:collective}/Products.DateRecurringIndex.git pushurl=${remotes:collective_push}/Products.DateRecurringIndex.git branch=master

--- a/tests.cfg
+++ b/tests.cfg
@@ -101,7 +101,6 @@ test-eggs =
     Products.CMFFormController
     Products.CMFPlacefulWorkflow [test]
     Products.CMFPlone [test]
-    Products.CMFQuickInstallerTool
     Products.CMFUid
     Products.DateRecurringIndex [test]
     Products.DCWorkflow

--- a/versions.cfg
+++ b/versions.cfg
@@ -214,7 +214,6 @@ Products.CMFEditions                  = 3.3.4
 Products.CMFFormController            = 4.1.3
 Products.CMFPlacefulWorkflow          = 2.0.3
 Products.CMFPlone                     = 5.2.1
-Products.CMFQuickInstallerTool        = 4.0.3
 Products.CMFUid                       = 3.1.0
 Products.contentmigration             = 2.2.1
 Products.DateRecurringIndex           = 3.0.1


### PR DESCRIPTION
And temporarily use CMFPlone branch maurits/no-qi, from https://github.com/plone/Products.CMFPlone/pull/3189