### PR TITLE
Checkout Zope

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -11,3 +11,4 @@ auto-checkout =
 # We may want to always check out these as well:
 # automatically added by mr.roboto
 # Unfortunately does not happen anymore, see https://github.com/plone/mr.roboto/issues/79
+    Zope


### PR DESCRIPTION
We need the fix from https://github.com/zopefoundation/Zope/pull/930
Otherwise on a fresh Plone Site with Python 2.7, you get this error on the homepage:

```
2020-11-16 12:29:22,661 ERROR   [waitress:358][waitress-1] Exception while serving /Plone
Traceback (most recent call last):
  File "/Users/maurits/shared-eggs/cp27m/waitress-1.4.4-py2.7.egg/waitress/channel.py", line 350, in service
    task.service()
  File "/Users/maurits/shared-eggs/cp27m/waitress-1.4.4-py2.7.egg/waitress/task.py", line 171, in service
    self.execute()
  File "/Users/maurits/shared-eggs/cp27m/waitress-1.4.4-py2.7.egg/waitress/task.py", line 441, in execute
    app_iter = self.channel.server.application(environ, start_response)
  File "/Users/maurits/shared-eggs/cp27m/Paste-3.4.3-py2.7.egg/paste/translogger.py", line 69, in __call__
    return self.application(environ, replacement_start_response)
  File "/Users/maurits/community/plone-coredev/5.2/src/Zope/src/ZPublisher/httpexceptions.py", line 30, in __call__
    return self.application(environ, start_response)
  File "/Users/maurits/community/plone-coredev/5.2/src/Zope/src/ZPublisher/WSGIPublisher.py", line 390, in publish_module
    start_response(status, headers)
  File "/Users/maurits/shared-eggs/cp27m/Paste-3.4.3-py2.7.egg/paste/translogger.py", line 68, in replacement_start_response
    return start_response(status, headers)
  File "/Users/maurits/shared-eggs/cp27m/waitress-1.4.4-py2.7.egg/waitress/task.py", line 414, in start_response
    "Header value %r is not a string in %r" % (v, (k, v))
AssertionError: Header value u'en' is not a string in ('Content-Language', u'en')
```

Caused by [plone.app.layout](https://github.com/plone/plone.app.layout/blob/3.4.6/plone/app/layout/viewlets/httpheaders.py#L34) setting a unicode language header.