### PR TITLE
Pin watchdog = 1.0.2 to Python 3 and watchdog = 0.10.6 to Python 2

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -180,7 +180,7 @@ smmap2 = 3.0.1
 stdlib-list = 0.6.0
 testresources = 2.0.1
 wadllib = 1.3.3
-watchdog = 0.10.2
+watchdog = 1.0.2
 wcwidth = 0.1.9
 wmctrl = 0.3
 wrapt = 1.12.1
@@ -188,9 +188,10 @@ z3c.dependencychecker = 2.7
 zest.pocompile = 1.5.0
 
 [versions:python27]
+check-manifest = 0.41
 keyring = 4.1.1
 PyGithub = 1.45
-check-manifest = 0.41
+watchdog = 0.10.6
 
 [versionannotations]
 # keep this alphabetical please


### PR DESCRIPTION
watchdog >= 1.0.0 is not compatible with Python 2. See:

https://github.com/gorakhargosh/watchdog/blob/7f7937d1fe6fa6d4b6b4f6f01aee9a9d91949642/setup.py#L128