### PR TITLE
Remove index on Plone 5.2

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -1,5 +1,4 @@
 [buildout]
-index = https://pypi.org/simple/
 extends =
     sources.cfg
     checkouts.cfg


### PR DESCRIPTION
This is already default value of the buildout version used by Plone 5.2.
See:

https://github.com/buildout/buildout/blob/6e00617ec15cb23dd3fd00b159e1df3497b72e1f/src/zc/buildout/easy_install.py#L64-L67