### PR TITLE
Checkout Products.MailHost branch for line separator fixes.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -177,7 +177,7 @@ Products.ExternalEditor             = git ${remotes:zope}/Products.ExternalEdito
 Products.ExternalMethod             = git ${remotes:zope}/Products.ExternalMethod.git pushurl=${remotes:zope_push}/Products.ExternalMethod.git branch=master
 Products.GenericSetup               = git ${remotes:zope}/Products.GenericSetup.git pushurl=${remotes:zope_push}/Products.GenericSetup.git branch=master
 Products.isurlinportal              = git ${remotes:plone}/Products.isurlinportal.git pushurl=${remotes:plone_push}/Products.isurlinportal.git branch=master
-Products.MailHost                   = git ${remotes:zope}/Products.MailHost.git pushurl=${remotes:zope_push}/Products.MailHost.git branch=master
+Products.MailHost                   = git ${remotes:zope}/Products.MailHost.git pushurl=${remotes:zope_push}/Products.MailHost.git branch=1letter/patch-smtp-bytes
 Products.Marshall                   = git ${remotes:plone}/Products.Marshall.git pushurl=${remotes:plone_push}/Products.Marshall.git branch=master
 Products.MimetypesRegistry          = git ${remotes:plone}/Products.MimetypesRegistry.git pushurl=${remotes:plone_push}/Products.MimetypesRegistry.git branch=master
 Products.PlacelessTranslationService= git ${remotes:plone}/Products.PlacelessTranslationService.git pushurl=${remotes:plone_push}/Products.PlacelessTranslationService.git branch=master


### PR DESCRIPTION
Add Products.MailHost to the test-eggs too, for now.
This is for testing https://github.com/zopefoundation/Products.MailHost/pull/36
This might mean tests need updating, or maybe production code.
Let's see.
This is not for merging, only for testing.