### PR TITLE
Remove Products.CMFFormController / portal_form_controller.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -70,7 +70,7 @@ plone.app.robotframework            = git ${remotes:plone}/plone.app.robotframew
 plone.app.testing                   = git ${remotes:plone}/plone.app.testing.git pushurl=${remotes:plone_push}/plone.app.testing.git branch=master
 plone.app.textfield                 = git ${remotes:plone}/plone.app.textfield.git pushurl=${remotes:plone_push}/plone.app.textfield.git branch=master
 plone.app.theming                   = git ${remotes:plone}/plone.app.theming.git pushurl=${remotes:plone_push}/plone.app.theming.git branch=master
-plone.app.upgrade                   = git ${remotes:plone}/plone.app.upgrade.git pushurl=${remotes:plone_push}/plone.app.upgrade.git branch=master
+plone.app.upgrade                   = git ${remotes:plone}/plone.app.upgrade.git pushurl=${remotes:plone_push}/plone.app.upgrade.git branch=maurits/no-form-controller
 plone.app.users                     = git ${remotes:plone}/plone.app.users.git pushurl=${remotes:plone_push}/plone.app.users.git branch=master
 plone.app.uuid                      = git ${remotes:plone}/plone.app.uuid.git pushurl=${remotes:plone_push}/plone.app.uuid.git branch=master
 plone.app.versioningbehavior        = git ${remotes:plone}/plone.app.versioningbehavior.git pushurl=${remotes:plone_push}/plone.app.versioningbehavior.git branch=master
@@ -152,9 +152,8 @@ Products.CMFCore                    = git ${remotes:zope}/Products.CMFCore.git p
 Products.CMFDiffTool                = git ${remotes:plone}/Products.CMFDiffTool.git pushurl=${remotes:plone_push}/Products.CMFDiffTool.git branch=master
 Products.CMFDynamicViewFTI          = git ${remotes:plone}/Products.CMFDynamicViewFTI.git pushurl=${remotes:plone_push}/Products.CMFDynamicViewFTI.git branch=master
 Products.CMFEditions                = git ${remotes:plone}/Products.CMFEditions.git pushurl=${remotes:plone_push}/Products.CMFEditions.git branch=master
-Products.CMFFormController          = git ${remotes:plone}/Products.CMFFormController.git pushurl=${remotes:plone_push}/Products.CMFFormController.git branch=master
 Products.CMFPlacefulWorkflow        = git ${remotes:plone}/Products.CMFPlacefulWorkflow.git pushurl=${remotes:plone_push}/Products.CMFPlacefulWorkflow.git branch=master
-Products.CMFPlone                   = git ${remotes:plone}/Products.CMFPlone.git pushurl=${remotes:plone_push}/Products.CMFPlone.git branch=master
+Products.CMFPlone                   = git ${remotes:plone}/Products.CMFPlone.git pushurl=${remotes:plone_push}/Products.CMFPlone.git branch=maurits/no-form-controller
 Products.CMFUid                     = git ${remotes:zope}/Products.CMFUid.git pushurl=${remotes:zope_push}/Products.CMFUid.git branch=master
 Products.contentmigration           = git ${remotes:plone}/Products.contentmigration.git pushurl=${remotes:plone_push}/Products.contentmigration.git branch=master
 Products.DateRecurringIndex         = git ${remotes:collective}/Products.DateRecurringIndex.git pushurl=${remotes:collective_push}/Products.DateRecurringIndex.git branch=master

--- a/tests.cfg
+++ b/tests.cfg
@@ -98,7 +98,6 @@ test-eggs =
     Products.CMFDiffTool
     Products.CMFDynamicViewFTI
     Products.CMFEditions
-    Products.CMFFormController
     Products.CMFPlacefulWorkflow [test]
     Products.CMFPlone [test]
     Products.CMFUid

--- a/versions.cfg
+++ b/versions.cfg
@@ -215,7 +215,6 @@ Products.CMFCore                      = 2.4.8
 Products.CMFDiffTool                  = 3.3.2
 Products.CMFDynamicViewFTI            = 6.0.3
 Products.CMFEditions                  = 3.3.4
-Products.CMFFormController            = 4.1.4
 Products.CMFPlacefulWorkflow          = 2.0.3
 Products.CMFPlone                     = 5.2.2
 Products.CMFUid                       = 3.1.0


### PR DESCRIPTION
Remove the package from the buildout files.
Use branches of `CMFPlone` (https://github.com/plone/Products.CMFPlone/pull/3226) and `plone.app.upgrade` (https://github.com/plone/plone.app.upgrade/pull/251).

We could also remove a `CMFFormController` line from `plone.app.testing`, but it's not in the way.
Could be done once we make a `plone.app.testing` branch for Plone 6 only.

In `plone.app.upgrade` I remove the `portal_form_controller` tool.
We could also conditionally remove it: check if the tool is an instance of `ZODB.broken.Broken`.
This is to support the theoretical case that someone explicitly adds the `CMFFormController` package, because it is still needed in a specific site.
But same could be done for `portal_quickinstaller`, and we don't do it there either.

Once green and approved, I can do the merges. The two PRs should be merged, and then on coredev we can keep using the master branches, and only merge the part of this PR that removes `CMFFormController` from the `test-eggs` and sources/versions.