### PR TITLE
Remove the zodb temporary storage.

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -82,6 +82,7 @@ eggs =
 # shared-blob = on
 environment-vars =
     zope_i18n_compile_mo_files true
+zodb-temporary-storage = off
 
 
 [zopescripts]

--- a/sources.cfg
+++ b/sources.cfg
@@ -70,7 +70,7 @@ plone.app.robotframework            = git ${remotes:plone}/plone.app.robotframew
 plone.app.testing                   = git ${remotes:plone}/plone.app.testing.git pushurl=${remotes:plone_push}/plone.app.testing.git branch=master
 plone.app.textfield                 = git ${remotes:plone}/plone.app.textfield.git pushurl=${remotes:plone_push}/plone.app.textfield.git branch=master
 plone.app.theming                   = git ${remotes:plone}/plone.app.theming.git pushurl=${remotes:plone_push}/plone.app.theming.git branch=master
-plone.app.upgrade                   = git ${remotes:plone}/plone.app.upgrade.git pushurl=${remotes:plone_push}/plone.app.upgrade.git branch=master
+plone.app.upgrade                   = git ${remotes:plone}/plone.app.upgrade.git pushurl=${remotes:plone_push}/plone.app.upgrade.git branch=maurits/remove-tempstorage
 plone.app.users                     = git ${remotes:plone}/plone.app.users.git pushurl=${remotes:plone_push}/plone.app.users.git branch=master
 plone.app.uuid                      = git ${remotes:plone}/plone.app.uuid.git pushurl=${remotes:plone_push}/plone.app.uuid.git branch=master
 plone.app.versioningbehavior        = git ${remotes:plone}/plone.app.versioningbehavior.git pushurl=${remotes:plone_push}/plone.app.versioningbehavior.git branch=master
@@ -153,7 +153,7 @@ Products.CMFDiffTool                = git ${remotes:plone}/Products.CMFDiffTool.
 Products.CMFDynamicViewFTI          = git ${remotes:plone}/Products.CMFDynamicViewFTI.git pushurl=${remotes:plone_push}/Products.CMFDynamicViewFTI.git branch=master
 Products.CMFEditions                = git ${remotes:plone}/Products.CMFEditions.git pushurl=${remotes:plone_push}/Products.CMFEditions.git branch=master
 Products.CMFPlacefulWorkflow        = git ${remotes:plone}/Products.CMFPlacefulWorkflow.git pushurl=${remotes:plone_push}/Products.CMFPlacefulWorkflow.git branch=master
-Products.CMFPlone                   = git ${remotes:plone}/Products.CMFPlone.git pushurl=${remotes:plone_push}/Products.CMFPlone.git branch=master
+Products.CMFPlone                   = git ${remotes:plone}/Products.CMFPlone.git pushurl=${remotes:plone_push}/Products.CMFPlone.git branch=maurits/remove-tempstorage
 Products.CMFUid                     = git ${remotes:zope}/Products.CMFUid.git pushurl=${remotes:zope_push}/Products.CMFUid.git branch=master
 Products.contentmigration           = git ${remotes:plone}/Products.contentmigration.git pushurl=${remotes:plone_push}/Products.contentmigration.git branch=master
 Products.DateRecurringIndex         = git ${remotes:collective}/Products.DateRecurringIndex.git pushurl=${remotes:collective_push}/Products.DateRecurringIndex.git branch=master
@@ -174,7 +174,6 @@ Products.PortalTransforms           = git ${remotes:plone}/Products.PortalTransf
 Products.PythonScripts              = git ${remotes:zope}/Products.PythonScripts.git pushurl=${remotes:zope_push}/Products.PythonScripts.git branch=master
 Products.Sessions                   = git ${remotes:zope}/Products.Sessions.git pushurl=${remotes:zope_push}/Products.Sessions.git branch=master
 Products.SiteErrorLog               = git ${remotes:zope}/Products.SiteErrorLog.git pushurl=${remotes:zope_push}/Products.SiteErrorLog.git branch=master
-Products.TemporaryFolder            = git ${remotes:zope}/Products.TemporaryFolder.git pushurl=${remotes:zope_push}/Products.TemporaryFolder.git branch=master
 Products.statusmessages             = git ${remotes:plone}/Products.statusmessages.git pushurl=${remotes:plone_push}/Products.statusmessages.git branch=master
 Products.validation                 = git ${remotes:plone}/Products.validation.git pushurl=${remotes:plone_push}/Products.validation.git branch=master
 Products.ZCatalog                   = git ${remotes:zope}/Products.ZCatalog.git pushurl=${remotes:zope_push}/Products.ZCatalog.git branch=master

--- a/versions.cfg
+++ b/versions.cfg
@@ -235,7 +235,6 @@ Products.PortalTransforms             = 3.1.10
 Products.SecureMailHost               = 1.1.2
 Products.Sessions                     = 4.8
 Products.SiteErrorLog                 = 5.4
-Products.TemporaryFolder              = 6.0
 Products.statusmessages               = 5.0.5
 Products.validation                   = 2.1.3
 Products.ZopeVersionControl           = 2.0.0


### PR DESCRIPTION
This PR contains:

- `CMFPlone` branch: remove `Products.TemporaryFolder` dependency. See https://github.com/plone/Products.CMFPlone/pull/3228
- `plone.app.upgrade` branch: remove the `/temp_folder` object, if it is broken. See https://github.com/plone/plone.app.upgrade/pull/252
- coredev: set `zodb-temporary-storage = off`, use the above branches, remove `Products.TemporaryFolder` from configs.

See https://github.com/plone/Products.CMFPlone/issues/2957

Warning for brave souls who extend Plone 6 coredev in production (hi @agitator): To avoid surprises the moment that this PR gets merged, you may want to temporarily include `Products.TemporaryFolder` in your eggs. Or set `zodb-temporary-storage = off` in your Plone instance part and check that Plone still starts up fine.

Let's check the current status of temporary storage in Plone.

Currently, if your buildout has `zodb-temporary-storage = on`, which is the default in `plone.recipe.zope2instance`, you get this in your `parts/instance/etc/zope.conf` :

```
<zodb_db temporary>
    # Temporary storage database (for sessions)
    <temporarystorage>
      name temporary storage for sessioning
    </temporarystorage>
    mount-point /temp_folder
    container-class Products.TemporaryFolder.TemporaryContainer
</zodb_db>
```

You then get a warning at startup:

> WARNING [TemporaryStorage:93][MainThread] DEPRECATED: Usage of the package tempstorage is deprecated, as it is known to randomly lose data.
> Especially on Zope 4. For details see https://github.com/zopefoundation/tempstorage/issues/8
> and https://github.com/zopefoundation/tempstorage

To get rid of this warning, you can set  `zodb-temporary-storage = off`. This should become the default in the recipe, but we may need to wait with that until Plone 6 arrives.

Some more notes for 5.2 and 6.0, independent of which `Products.TemporaryStorage` version you have, if any:

- These two session-related items are created automatically on startup: `session_data_manager` and `browser_id_manager`. The `session_data_manager` points to `/temp_folder` in its properties, but with the current `Products.Sessions` version, you don't get warnings or errors, unless someone actually tries to access `request.SESSION`, which core Plone never does.
- If you have a `temp_folder` object in the Zope root, but you remove `temporarystorage` from `zope.conf`, then startup warns: `ConfigurationError: No database configured for mount point at /temp_folder`. You see this warning every time you access the Zope root. Zope and Plone do work fine. We should avoid this warning.
- Delete `temp_folder`, delete `temporarystorage` from `zope.conf`: no warnings, all seems fine. This is what we want in Plone 6.

Current Plone coredev 5.2 with **Products.TemporaryFolder 5.3**:

- The `temp_folder` object is created on startup. This is unwanted.
- Manually delete `temp_folder` and restart: temp_folder is recreated.

Plone coredev 5.2 with **Products.TemporaryFolder 6.0**:

- The `temp_folder` is **not** created or recreated on startup. This is the main advantage of this version. But for the few existing add-ons or sites that do use `temp_folder`, this is an unwanted change, at least breaking the tests and the setup instructions. It is tempting to use this version in coredev 5.2. But the positive points of avoiding a warning and avoiding creating an unnecessary object, are outweighed by possible real problems for a few add-ons and sites. So let's not do this in 5.2.

Plone coredev 5.2 with dependency on **Products.TemporaryFolder removed** from CMFPlone:

- With the default `zope.conf`, startup fails with an error: `Error: unknown type name: u'temporarystorage'.` We must avoid this, so we cannot remove the dependency in Plone 5.2.

Plone **coredev 6.0** with dependency on **Products.TemporaryFolder removed** from CMFPlone:

- Startup fails with an error: `Error: unknown type name: u'temporarystorage'.` So `zodb-temporary-storage` should be switched off by default in the recipe. This can only be done when master no longer targets 5.2, and I don't want this split just yet. This coredev PR sets it to `off` in `core.cfg`.
- Remove `temporarystorage` from `zope.conf`: startup succeeds. No warnings. The `temp_folder` object is marked as Broken in the ZMI.
- Delete `temp_folder`. All seems well. You do get a warning when accessing Plone: `[OFS.Uninstalled:84][waitress-0] Could not import class 'MountedObject' from module 'Products.ZODBMountPoint.MountedObject'` A database pack does not help.
- Ah, the Zope root has a dictionary `_mount_points` which has a `MountedObject` inside it, pointing to `temp_folder`. I now remove  this in plone.app.upgrade and then the warning is gone.
- With the upgrade step run and after a `zeopack`, `bin/instance zodbverify` no longer complains about anything.
