### PR TITLE
Uses TZ = UTC in buildout

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -180,6 +180,9 @@ recipe = collective.xmltestreport
 eggs = ${buildout:test-eggs}
 defaults = ['--auto-color', '--auto-progress', '--ignore_dir=.git', '--ignore_dir=bower_components', '--ignore_dir=node_modules']
 environment = environment
+initialization =
+# Ensures that tests using datetime will work locally on machines using TZ = GMT
+    os.environ['TZ'] = 'UTC'
 
 [robot]
 recipe = zc.recipe.egg


### PR DESCRIPTION
This ensures that tests using datetime will work locally on machines using TZ = GMT

Branch 6.0