### PR TITLE
Set timezone in bin/test.

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -212,6 +212,8 @@ environment = environment
 initialization =
 # Ensures that tests using datetime will work locally on machines using TZ = GMT
     os.environ['TZ'] = 'UTC'
+    import time
+    time.tzset()
 
 [robot]
 recipe = zc.recipe.egg


### PR DESCRIPTION
Calling time.tzset is needed on Python 3.8,
otherwise the TZ environment variable that we add has no effect.
See discussion starting with this comment:
https://github.com/plone/buildout.coredev/pull/693#issuecomment-774160597