### PR TITLE
New branches after templates have been converted to bootstrap 5

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -49,9 +49,9 @@ plone.app.contenttypes              = git ${remotes:plone}/plone.app.contenttype
 plone.app.controlpanel              = git ${remotes:plone}/plone.app.controlpanel.git pushurl=${remotes:plone_push}/plone.app.controlpanel.git branch=3.x
 plone.app.customerize               = git ${remotes:plone}/plone.app.customerize.git pushurl=${remotes:plone_push}/plone.app.customerize.git branch=master
 plone.app.debugtoolbar              = git ${remotes:plone}/plone.app.debugtoolbar.git pushurl=${remotes:plone_push}/plone.app.debugtoolbar.git branch=master
-plone.app.dexterity                 = git ${remotes:plone}/plone.app.dexterity.git pushurl=${remotes:plone_push}/plone.app.dexterity.git branch=master
+plone.app.dexterity                 = git ${remotes:plone}/plone.app.dexterity.git pushurl=${remotes:plone_push}/plone.app.dexterity.git branch=2.6.x
 plone.app.discussion                = git ${remotes:plone}/plone.app.discussion.git pushurl=${remotes:plone_push}/plone.app.discussion.git branch=3.x
-plone.app.event                     = git ${remotes:plone}/plone.app.event.git pushurl=${remotes:plone_push}/plone.app.event.git branch=master
+plone.app.event                     = git ${remotes:plone}/plone.app.event.git pushurl=${remotes:plone_push}/plone.app.event.git branch=3.2.x
 plone.app.folder                    = git ${remotes:plone}/plone.app.folder.git pushurl=${remotes:plone_push}/plone.app.folder.git branch=1.2.x
 plone.app.i18n                      = git ${remotes:plone}/plone.app.i18n.git pushurl=${remotes:plone_push}/plone.app.i18n.git branch=master
 plone.app.imaging                   = git ${remotes:plone}/plone.app.imaging.git pushurl=${remotes:plone_push}/plone.app.imaging.git branch=2.0.x
@@ -67,7 +67,7 @@ plone.app.portlets                  = git ${remotes:plone}/plone.app.portlets.gi
 plone.app.querystring               = git ${remotes:plone}/plone.app.querystring.git pushurl=${remotes:plone_push}/plone.app.querystring.git branch=master
 plone.app.redirector                = git ${remotes:plone}/plone.app.redirector.git pushurl=${remotes:plone_push}/plone.app.redirector.git branch=1.3.x
 plone.app.referenceablebehavior     = git ${remotes:plone}/plone.app.referenceablebehavior.git pushurl=${remotes:plone_push}/plone.app.referenceablebehavior.git branch=master
-plone.app.registry                  = git ${remotes:plone}/plone.app.registry.git pushurl=${remotes:plone_push}/plone.app.registry.git branch=master
+plone.app.registry                  = git ${remotes:plone}/plone.app.registry.git pushurl=${remotes:plone_push}/plone.app.registry.git branch=1.7.x
 plone.app.relationfield             = git ${remotes:plone}/plone.app.relationfield.git pushurl=${remotes:plone_push}/plone.app.relationfield.git branch=1.x
 plone.app.robotframework            = git ${remotes:plone}/plone.app.robotframework.git pushurl=${remotes:plone_push}/plone.app.robotframework.git branch=1.3.x
 plone.app.testing                   = git ${remotes:plone}/plone.app.testing.git pushurl=${remotes:plone_push}/plone.app.testing.git branch=5.x
@@ -83,7 +83,7 @@ plone.app.widgets                   = git ${remotes:plone}/plone.app.widgets.git
 plone.app.workflow                  = git ${remotes:plone}/plone.app.workflow.git pushurl=${remotes:plone_push}/plone.app.workflow.git branch=3.x
 plone.app.z3cform                   = git ${remotes:plone}/plone.app.z3cform.git pushurl=${remotes:plone_push}/plone.app.z3cform.git branch=3.0.x
 plone.autoform                      = git ${remotes:plone}/plone.autoform.git pushurl=${remotes:plone_push}/plone.autoform.git branch=master
-plone.batching                      = git ${remotes:plone}/plone.batching.git pushurl=${remotes:plone_push}/plone.batching.git branch=master
+plone.batching                      = git ${remotes:plone}/plone.batching.git pushurl=${remotes:plone_push}/plone.batching.git branch=1.1.x
 plone.behavior                      = git ${remotes:plone}/plone.behavior.git pushurl=${remotes:plone_push}/plone.behavior.git branch=master
 plone.browserlayer                  = git ${remotes:plone}/plone.browserlayer.git pushurl=${remotes:plone_push}/plone.browserlayer.git branch=master
 plone.cachepurging                  = git ${remotes:plone}/plone.cachepurging.git pushurl=${remotes:plone_push}/plone.cachepurging.git branch=1.x


### PR DESCRIPTION
This backports:
https://github.com/plone/buildout.coredev/pull/703/files
to Plone 5.1