### PR TITLE
5.2: Use Zope 4.5.4 versions.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -2,7 +2,7 @@
 # This file is part of buildout.coredev repository: https://github.com/plone/buildout.coredev
 # The plone release team is responsible for it,
 # if you have suggestions, please open an issue at: https://github.com/plone/buildout.coredev/issues
-extends = https://zopefoundation.github.io/Zope/releases/4.5.3/versions.cfg
+extends = https://zopefoundation.github.io/Zope/releases/4.5.4/versions.cfg
 
 [versions]
 ##############################################################################
@@ -82,7 +82,7 @@ zope.keyreference = 4.2.0
 zope.mkzeoinstance = 4.1
 zope.password = 4.3.1
 
-# Newer versions than from the current Zope 4.5.3.  Remove after Zope updates it.
+# Newer versions than from the current Zope 4.5.4.  Remove after Zope updates it.
 
 ##############################################################################
 # External dependencies


### PR DESCRIPTION
The only change in the versions is Zope 4.5.4, no other packages were changed.