### PR TITLE
Use zope.publisher and zope.schema from Zope 4.5.5.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -85,14 +85,6 @@ zope.password = 4.3.1
 # Newer versions than from the current Zope 4.5.5.  Remove after Zope updates it.
 
 
-# OLDER versions than from the current Zope 4.5.5.
-# Remove after we trust them.
-# They should be okay, but I do not want to include them this close to releasing Plone 5.2.4.
-# zope.publisher = 6.0.0
-zope.publisher = 5.2.1
-# zope.schema = 6.1.0
-zope.schema = 6.0.0
-
 ##############################################################################
 # External dependencies
 calmjs.parse = 1.2.5


### PR DESCRIPTION
I did not trust these versions enough to include them in 5.2.4, fearing some breakage.
But let's get them in now.