### PR TITLE
use latest version of setuptools with easy_install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-setuptools==50.3.2
+setuptools==51.3.3
 zc.buildout==2.13.3
 wheel
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -14,7 +14,7 @@ extends = https://zopefoundation.github.io/Zope/releases/5.1.2/versions.cfg
 
 # Basics
 # !! keep in sync with requirements.txt !!
-setuptools = 50.3.2
+setuptools = 51.3.3
 zc.buildout = 2.13.3
 
 # windows specific


### PR DESCRIPTION
setuptools 52 drops easy_install top level model. buildout 3 adresses this, but with buildout to we can not get further than here.