### PR TITLE
Update calmjs.parse to fix a deprecation warning

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -95,7 +95,7 @@ zope.schema = 6.1.0
 
 ##############################################################################
 # External dependencies
-calmjs.parse = 1.2.4
+calmjs.parse = 1.2.5
 cssselect = 1.1.0
 decorator = 4.4.2
 enum34 = 1.1.10


### PR DESCRIPTION
```
/home/ale/.buildout/eggs/calmjs.parse-1.2.4-py3.8.egg/calmjs/parse/io.py:7: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  from collections import Iterable    
```