### PR TITLE
Uses ignore-develop = True in omelette

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -135,7 +135,7 @@ eggs =
 
 [packages]
 recipe = collective.recipe.omelette
-ignore-develop = False
+ignore-develop = True
 eggs =
     ${test:eggs}
 ignores =


### PR DESCRIPTION
Development packages are already in the src. Including them in the omelette will leave them in two places.