### PR TITLE
Use Zope 4.6.2 on Plone 5.2

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -2,7 +2,7 @@
 # This file is part of buildout.coredev repository: https://github.com/plone/buildout.coredev
 # The plone release team is responsible for it,
 # if you have suggestions, please open an issue at: https://github.com/plone/buildout.coredev/issues
-extends = https://zopefoundation.github.io/Zope/releases/4.5.5/versions.cfg
+extends = https://zopefoundation.github.io/Zope/releases/4.6.2/versions.cfg
 
 [versions]
 ##############################################################################
@@ -83,7 +83,7 @@ zope.keyreference = 4.2.0
 zope.mkzeoinstance = 4.1
 zope.password = 4.3.1
 
-# Newer versions than from the current Zope 4.5.5.  Remove after Zope updates it.
+# Newer versions than from the current Zope 4.6.2.  Remove after Zope updates it.
 
 
 ##############################################################################
@@ -289,7 +289,6 @@ argh = 0.26.2
 args = 0.1.0
 asn1crypto = 1.3.0
 cached-property = 1.5.1
-cffi = 1.14.5
 check-manifest = 0.45
 clint = 0.5.1
 cryptography = 3.3.2
@@ -381,5 +380,3 @@ ply =
     3.4 previously pinned for slimit, but calmjs.parse needs 3.6+, though it comes with pre-generated tab files for up to 3.11. See https://github.com/dabeaz/ply/issues/82,
 Unidecode =
     Unidecode 0.04.{2-9} breaks tests
-zope.interface =
-    5.1 gives several test failures

--- a/versions.cfg
+++ b/versions.cfg
@@ -85,6 +85,11 @@ zope.password = 4.3.1
 
 # Newer versions than from the current Zope 4.6.2.  Remove after Zope updates it.
 
+# Older versions than pinned in Zope.  Remove only if we are sure newer versions are safe.
+# See versionannotations below.
+zope.component = 4.6.2
+# Maybe zope.interface 5.4.0 is too new as well, in that case we should pin:
+# zope.interface = 5.2.0
 
 ##############################################################################
 # External dependencies
@@ -380,3 +385,5 @@ ply =
     3.4 previously pinned for slimit, but calmjs.parse needs 3.6+, though it comes with pre-generated tab files for up to 3.11. See https://github.com/dabeaz/ply/issues/82,
 Unidecode =
     Unidecode 0.04.{2-9} breaks tests
+zope.component =
+    5.0.0 causes a few problems.  See https://github.com/plone/buildout.coredev/pull/725#issuecomment-872272811


### PR DESCRIPTION
Removed cffi pin, Zope has it already.
Removed outdated zope.interface 5.1 annotation.