### PR TITLE
Update feedparser for 3.9 compatibility, keep old version for Python 2.7.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -97,7 +97,6 @@ calmjs.parse = 1.2.5
 cssselect = 1.1.0
 decorator = 4.4.2
 enum34 = 1.1.10
-feedparser = 5.2.1
 interlude = 1.3.1
 jsonschema = 3.2.0
 lockfile = 0.12.2
@@ -339,10 +338,13 @@ zest.pocompile = 1.5.0
 
 [versions:python3]
 jeepney = 0.4.3
+feedparser = 6.0.8
+sgmllib3k = 1.0.0
 
 [versions:python27]
 check-manifest = 0.41
 docutils = 0.15.2
+feedparser = 5.2.1
 functools32 = 3.2.3.post2
 futures = 3.3.0
 keyring = 4.1.1


### PR DESCRIPTION
Python 3.9 fails with:
[...]
```
  File "/home/_thet/data/dev/pavel-hisa/pavelhaus.buildout/eggs/plone.app.portlets-4.4.6-py3.9.egg/plone/app/portlets/portlets/rss.py", line 11, in <module>
    import feedparser
  File "/home/_thet/data/dev/pavel-hisa/pavelhaus.buildout/eggs/feedparser-5.2.1-py3.9.egg/feedparser.py", line 93, in <module>
    _base64decode = getattr(base64, 'decodebytes', base64.decodestring)
zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "/home/_thet/data/dev/pavel-hisa/pavelhaus.buildout/eggs/plone.app.portlets-4.4.6-py3.9.egg/plone/app/portlets/portlets/configure.zcml", line 61.4-68.10
    File "/home/_thet/data/dev/pavel-hisa/pavelhaus.buildout/parts/instance/etc/site.zcml", line 15.2-15.55
    File "/home/_thet/data/dev/pavel-hisa/pavelhaus.buildout/parts/instance/etc/package-includes/002-bda.aaf.site-configure.zcml", line 1.0-1.56
    File "/home/_thet/data/dev/pavel-hisa/pavelhaus.buildout/src-aaf/bda.aaf.site/src/bda/aaf/site/configure.zcml", line 16.2-16.34
    File "/home/_thet/data/dev/pavel-hisa/pavelhaus.buildout/src-aaf/bda.aaf.site/src/bda/aaf/site/overrides/configure.zcml", line 5.2-5.44
    File "/home/_thet/data/dev/pavel-hisa/pavelhaus.buildout/src-aaf/bda.aaf.site/src/bda/aaf/site/overrides/overrides.zcml", line 44.2-44.40
    File "/home/_thet/data/dev/pavel-hisa/pavelhaus.buildout/eggs/collective.venue-4.1-py3.9.egg/collective/venue/configure.zcml", line 11.2-11.38
    File "/home/_thet/data/dev/pavel-hisa/pavelhaus.buildout/eggs/plone.app.event-3.2.10-py3.9.egg/plone/app/event/configure.zcml", line 14.2-14.42
    File "/home/_thet/data/dev/pavel-hisa/pavelhaus.buildout/eggs/plone.app.portlets-4.4.6-py3.9.egg/plone/app/portlets/configure.zcml", line 16.4-16.35
    AttributeError: module 'base64' has no attribute 'decodestring'

```