### PR TITLE
Pin zope.schema back to 6.0.0.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -88,6 +88,7 @@ zope.password = 4.3.1
 # Older versions than pinned in Zope.  Remove only if we are sure newer versions are safe.
 # See versionannotations below.
 zope.component = 4.6.2
+zope.schema = 6.0.0
 # Maybe zope.interface 5.4.0 is too new as well, in that case we should pin:
 # zope.interface = 5.2.0
 
@@ -389,3 +390,5 @@ Unidecode =
     Unidecode 0.04.{2-9} breaks tests
 zope.component =
     5.0.0 causes a few problems.  See https://github.com/plone/buildout.coredev/pull/725#issuecomment-872272811
+zope.schema =
+    6.1.0 causes problems with booleans.  See https://community.plone.org/t/plone-5-2-5-soft-released/14150/9?u=mauritsvanrees


### PR DESCRIPTION
6.1.0 causes problems with booleans.
For example, easyform cannot mail anymore.
See https://community.plone.org/t/plone-5-2-5-soft-released/14150/9?u=mauritsvanrees