### PR TITLE
Moved versions from tests.cfg to versions.cfg.

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -117,45 +117,6 @@ test-eggs =
     repoze.xmliter
     ${buildout:custom-eggs}
 
-[versions]
-# egg versions that are not part of the release, but should still be pinned
-# so our development builds are repeatable
-# jenkins versions
-argcomplete = 1.12.3
-argh = 0.26.2
-build = 0.1.0
-cached-property = 1.5.2
-check-manifest = 0.46
-Deprecated = 1.2.10
-distro = 1.5.0
-fancycompleter = 0.9.1
-FormEncode = 1.3.1
-gitdb2 = 2.0.6
-GitPython = 3.0.5
-html5lib = 1.1i
-httplib2 = 0.18.1
-launchpadlib = 1.10.13
-lazr.restfulclient = 0.14.3
-lazr.uri = 1.0.5
-oauthlib = 3.1.0
-pdbpp = 0.10.2
-pep517 = 0.9.1
-progress = 1.5
-prompt-toolkit = 1.0.18
-PyGithub = 1.47
-pyrepl = 0.9.0
-pyroma = 2.6
-smmap = 3.0.4
-smmap2 = 3.0.1
-stdlib-list = 0.7.0
-testresources = 2.0.1
-typing-extensions = 3.7.4.3
-wadllib = 1.3.4
-wcwidth = 0.2.5
-wmctrl = 0.3
-wrapt = 1.12.1
-z3c.dependencychecker = 2.7
-zest.pocompile = 1.5.0
 
 [versionannotations]
 # keep this alphabetical please

--- a/versions.cfg
+++ b/versions.cfg
@@ -289,6 +289,47 @@ plone.tiles                           = 2.3.0
 plone.jsonserializer                  = 0.9.10
 
 
+# egg versions formerly in tests.cfg.
+# We said they were not part of the release, but should still be pinned
+# so our development builds are repeatable.
+# But real dependencies creep in anyway, like cryptography that is pulled in by restapi.
+argcomplete = 1.12.3
+argh = 0.26.2
+build = 0.1.0
+cached-property = 1.5.2
+check-manifest = 0.46
+Deprecated = 1.2.10
+distro = 1.5.0
+fancycompleter = 0.9.1
+FormEncode = 1.3.1
+gitdb2 = 2.0.6
+GitPython = 3.0.5
+html5lib = 1.1i
+httplib2 = 0.18.1
+launchpadlib = 1.10.13
+lazr.restfulclient = 0.14.3
+lazr.uri = 1.0.5
+oauthlib = 3.1.0
+pdbpp = 0.10.2
+pep517 = 0.9.1
+progress = 1.5
+prompt-toolkit = 1.0.18
+PyGithub = 1.47
+pyrepl = 0.9.0
+pyroma = 2.6
+smmap = 3.0.4
+smmap2 = 3.0.1
+stdlib-list = 0.7.0
+testresources = 2.0.1
+typing-extensions = 3.7.4.3
+wadllib = 1.3.4
+wcwidth = 0.2.5
+wmctrl = 0.3
+wrapt = 1.12.1
+z3c.dependencychecker = 2.7
+zest.pocompile = 1.5.0
+
+
 [versionannotations]
 # keep this alphabetical please
 ply =


### PR DESCRIPTION
Already done in February on coredev 5.2: 9b96c7ff22e46f31e441f68835a0ee89d94a17ec
I have not changed any versions, it is a simple copy.