### PR TITLE
[6.0] Do not merge: test plone.i18n.git branch=cleanup-and-upgrade-unidecode-3

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -9,6 +9,7 @@ auto-checkout =
     Products.CMFPlone
     plone.restapi
 # manual added
+    plone.i18n
 # automatically added by mr.roboto
     mockup
     plone.app.registry

--- a/sources.cfg
+++ b/sources.cfg
@@ -91,7 +91,7 @@ plone.event                         = git ${remotes:plone}/plone.event.git pushu
 plone.folder                        = git ${remotes:plone}/plone.folder.git pushurl=${remotes:plone_push}/plone.folder.git branch=master
 plone.formwidget.namedfile          = git ${remotes:plone}/plone.formwidget.namedfile.git pushurl=${remotes:plone_push}/plone.formwidget.namedfile.git branch=master
 plone.formwidget.recurrence         = git ${remotes:plone}/plone.formwidget.recurrence.git pushurl=${remotes:plone_push}/plone.formwidget.recurrence.git branch=master
-plone.i18n                          = git ${remotes:plone}/plone.i18n.git pushurl=${remotes:plone_push}/plone.i18n.git branch=master
+plone.i18n                          = git ${remotes:plone}/plone.i18n.git pushurl=${remotes:plone_push}/plone.i18n.git branch=cleanup-and-upgrade-unidecode-3
 plone.indexer                       = git ${remotes:plone}/plone.indexer.git pushurl=${remotes:plone_push}/plone.indexer.git branch=master
 plone.intelligenttext               = git ${remotes:plone}/plone.intelligenttext.git pushurl=${remotes:plone_push}/plone.intelligenttext.git branch=master
 plone.keyring                       = git ${remotes:plone}/plone.keyring.git pushurl=${remotes:plone_push}/plone.keyring.git branch=master

--- a/versions.cfg
+++ b/versions.cfg
@@ -122,7 +122,7 @@ simplejson = 3.17.2
 
 # Special pins, see annotations
 ply = 3.11
-unidecode = 0.04.1
+unidecode = 1.2.0
 
 ##############################################################################
 # Plone release


### PR DESCRIPTION
see https://github.com/plone/buildout.coredev/pull/573

the branch at plone.i18n needs an upgrade of `Unidecode`. But Jenkins is not able to test a `buildout coredev` branch and a package branch at the same time. This one verifies green tests. Then manual work need to be done.