### PR TITLE
Upgrade Genshi and Products.PrintingMailHost for Python 3.9 compatibility

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -24,7 +24,7 @@ cachecontrol = 0.12.6
 click = 7.1.2
 collective.recipe.omelette = 1.0.0
 freezegun = 0.3.15
-Genshi = 0.7.3
+Genshi = 0.7.5
 incremental = 17.5.0
 plone.recipe.alltests = 1.5.2
 plone.recipe.precompiler = 0.7.2
@@ -274,7 +274,7 @@ z3c.objpath                           = 1.2
 z3c.relationfield                     = 0.9.0
 z3c.unconfigure                       = 1.1
 zc.relationship                       = 2.0.post1
-Products.PrintingMailHost             = 1.1.5
+Products.PrintingMailHost             = 1.1.6
 Products.PDBDebugMode                 = 2.0
 
 # New: Mosaic and related


### PR DESCRIPTION
This PR upgrades two dependencies to support Python 3.9 compatibility while keeping 2.7 compatibility.