### PR TITLE
Create plone-register-icons and plone-register-flags scripts.

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -106,6 +106,8 @@ interpreter = zopepy
 scripts =
     zopepy
     plone-compile-resources
+    plone-register-icons
+    plone-register-flags
 
 
 [packages]


### PR DESCRIPTION
Add scripts to register new bootstrap-icon and svg-country-flags icons in plone.staticresource.

Note: This does not happen very often, only if a new release - mainly from bootstrap-icons - with new icons is released.