### PR TITLE
build(versions): Fix local devel buildout error

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -28,6 +28,7 @@ cachecontrol = 0.12.6
 click = 8.0.1
 click-default-group = 1.2.2
 collective.recipe.omelette = 1.1.0
+collective.recipe.plonesite = 1.12.0
 collective.recipe.vscode = 0.1.7
 Genshi = 0.7.5
 incremental = 21.3.0


### PR DESCRIPTION
$ bin/buildout
    ...
    While:
      Installing.
      Uninstalling plonesite-volto.
      Installing recipe collective.recipe.plonesite.
      Getting distribution for 'collective.recipe.plonesite'.
    Error: Picked: collective.recipe.plonesite = 1.12.0

    The `collective.recipe.plonesite` egg does not have a version pin and `allow-picked-versions = false`.

    To resolve this, add

        collective.recipe.plonesite = 1.12.0

    to the [versions] section,

    OR set `allow-picked-versions = true`.