### PR TITLE
Remove stale docs branches

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -10,9 +10,7 @@ auto-checkout =
     plone.restapi
     Zope
 # also always get the documentation to be ready for edits
-    docs-classicui
-    docs-backend
-    docs-volto
+    docs-6-dev
 # automatically added by mr.roboto
     plone.rest
     plone.volto


### PR DESCRIPTION
We now use `6-dev` as the primary branch for development on Plone Docs. The other branches are stale and will not be used. I hope I did this correctly.