### PR TITLE
Try latest pip 22 and setuptools.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-setuptools==59.6.0
-zc.buildout==3.0.0rc1
-pip==21.3.1
-wheel==0.37.0
+setuptools==59.8.0
+zc.buildout==3.0.0rc2
+pip==22.0.3
+wheel==0.37.1
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -14,10 +14,10 @@ extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.
 
 # Basics
 # !! keep in sync with requirements.txt !!
-setuptools = 59.6.0
-zc.buildout = 3.0.0rc1
-pip = 21.3.1
-wheel = 0.37.0
+setuptools = 59.8.0
+zc.buildout = 3.0.0rc2
+pip = 22.0.3
+wheel = 0.37.1
 
 # windows specific
 nt-svcutils = 2.13.0
@@ -342,6 +342,8 @@ pyjwt =
     plone.restapi fails with PyJWT >=2 - see https://github.com/plone/plone.restapi/issues/1193
 robotframework =
     Since 3.2.x the robot.parsing module API has breaking changes, thus we need to adopt before upgrading.
+setuptools =
+    60+ does not work with buildout 3, throwing a TypeError: dist must be a Distribution instance
 smmap2 =
     Needs to be a 2 series
 zope.component =


### PR DESCRIPTION
I run into an error though:

```
Installing instance.
While:
  Installing instance.
  Getting distribution for 'pygments==2.11.2'.

An internal error occurred due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/Users/maurits/community/plone-coredev/6.0/lib/python3.9/site-packages/zc/buildout/buildout.py", line 2250, in main
    getattr(buildout, command)(args)
  File "/Users/maurits/community/plone-coredev/6.0/lib/python3.9/site-packages/zc/buildout/buildout.py", line 855, in install
    installed_files = self[part]._call(recipe.install)
  File "/Users/maurits/community/plone-coredev/6.0/lib/python3.9/site-packages/zc/buildout/buildout.py", line 1651, in _call
    return f()
  File "/Users/maurits/shared-eggs/cp39/plone.recipe.zope2instance-6.10.2-py3.9.egg/plone/recipe/zope2instance/recipe.py", line 155, in install
    installed.extend(self.install_scripts())
  File "/Users/maurits/shared-eggs/cp39/plone.recipe.zope2instance-6.10.2-py3.9.egg/plone/recipe/zope2instance/recipe.py", line 949, in install_scripts
    requirements, ws = self.egg.working_set(["plone.recipe.zope2instance"])
  File "/Users/maurits/shared-eggs/cp39/zc.recipe.egg-2.0.7-py3.9.egg/zc/recipe/egg/egg.py", line 78, in working_set
    ws = self._working_set(
  File "/Users/maurits/shared-eggs/cp39/zc.recipe.egg-2.0.7-py3.9.egg/zc/recipe/egg/egg.py", line 161, in _working_set
    ws = zc.buildout.easy_install.install(
  File "/Users/maurits/community/plone-coredev/6.0/lib/python3.9/site-packages/zc/buildout/easy_install.py", line 965, in install
    return installer.install(specs, working_set)
  File "/Users/maurits/community/plone-coredev/6.0/lib/python3.9/site-packages/zc/buildout/easy_install.py", line 738, in install
    for dist in self._get_dist(req, ws):
  File "/Users/maurits/shared-eggs/cp39/plone.versioncheck-1.7.0-py3.9.egg/plone/versioncheck/tracking.py", line 24, in get_dist
    dists = old_get_dist(self, requirement, *ags, **kw)
  File "/Users/maurits/community/plone-coredev/6.0/lib/python3.9/site-packages/zc/buildout/easy_install.py", line 550, in _get_dist
    dist, avail = self._satisfied(requirement)
  File "/Users/maurits/community/plone-coredev/6.0/lib/python3.9/site-packages/zc/buildout/easy_install.py", line 346, in _satisfied
    return None, self._obtain(req, source)
  File "/Users/maurits/community/plone-coredev/6.0/lib/python3.9/site-packages/zc/buildout/easy_install.py", line 473, in _obtain
    if index.obtain(requirement) is None:
  File "/Users/maurits/community/plone-coredev/6.0/lib/python3.9/site-packages/setuptools/package_index.py", line 492, in obtain
    self.prescan()
  File "/Users/maurits/community/plone-coredev/6.0/lib/python3.9/site-packages/setuptools/package_index.py", line 534, in prescan
    list(map(self.scan_url, self.to_scan))
  File "/Users/maurits/community/plone-coredev/6.0/lib/python3.9/site-packages/setuptools/package_index.py", line 818, in scan_url
    self.process_url(url, True)
  File "/Users/maurits/community/plone-coredev/6.0/lib/python3.9/site-packages/zc/buildout/patches.py", line 120, in process_url
    plinks = list(parse_links(html_page))
TypeError: wrapper_wrapper() missing 1 required positional argument: 'use_deprecated_html5lib'
```