### PR TITLE
Don't use egg caching in GA on Windows

### DIFF
--- a/.github/workflows/run-buildout.yml
+++ b/.github/workflows/run-buildout.yml
@@ -38,6 +38,9 @@ jobs:
           eggs
         key: eggs-${{ hashFiles('**/*.cfg') }}
         restore-keys: eggs-
+      # XXX: buildout fails on Windows when it has cache of eggs. See:
+      # https://github.com/plone/buildout.coredev/issues/772
+      if: matrix.os != 'windows-latest'
     - name: Run buildout
       run: |
         buildout


### PR DESCRIPTION
`buildout` 2 fails on Windows when it has cache of eggs.

Fixes #772 