### PR TITLE
5.2: always checkout Zope 4.x.

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -8,6 +8,7 @@ auto-checkout =
     plone.app.upgrade
     Products.CMFPlone
     plone.restapi
+    Zope
 # Automatically added by mr.roboto after PR merge:
     plone.outputfilters
     plone.app.linkintegrity

--- a/versions.cfg
+++ b/versions.cfg
@@ -2,7 +2,10 @@
 # This file is part of buildout.coredev repository: https://github.com/plone/buildout.coredev
 # The plone release team is responsible for it,
 # if you have suggestions, please open an issue at: https://github.com/plone/buildout.coredev/issues
-extends = https://zopefoundation.github.io/Zope/releases/4.7/versions.cfg
+# Based on latest development Zope:
+extends = https://raw.githubusercontent.com/zopefoundation/Zope/4.x/versions.cfg
+# Based on released Zope:
+# extends = https://zopefoundation.github.io/Zope/releases/4.7/versions.cfg
 
 [versions]
 ##############################################################################
@@ -83,14 +86,9 @@ zope.keyreference = 4.2.0
 zope.mkzeoinstance = 4.1
 zope.password = 4.3.1
 
-# Newer versions than from the current Zope 4.7.  Remove after Zope updates it.
-zope.i18n = 4.8.0
-collective.recipe.template = 2.2
-
 # Older/newer versions than pinned in Zope.  Remove only if we are sure Zope has has a good version now.
 # Each pin should have a comment in versionannotations below.
 zope.component = 4.6.2
-zope.schema = 6.1.1
 
 ##############################################################################
 # External dependencies


### PR DESCRIPTION
And extend the versions from this branch.
Then we can know of any incompatibilities before a new Zope release is created.
We have done this in Plone 6 coredev for a few months now.