### PR TITLE
greenlet add python 3.9 support on version 0.4.16

### DIFF
--- a/wsgioptions.cfg
+++ b/wsgioptions.cfg
@@ -87,6 +87,6 @@ output = ${buildout:bin-directory}/gunicorn-instance
 mode = 755
 
 [versions]
-greenlet = 0.4.15
+greenlet = 0.4.16
 gunicorn = 19.9.0
 uWSGI = 2.0.18


### PR DESCRIPTION
So I updated version to run `bin/buildout -c wsgioptions.cfg` on python 3.9.
I do not update CHANGELOG because it's a very little change and I'm not sue it's useful for this kind of change