### PR TITLE
Plone 6: Update several versions to latest.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -106,6 +106,7 @@ functools32 = 3.2.3.post2
 futures = 3.3.0
 interlude = 1.3.1
 gunicorn = 20.1.0
+importlib-resources = 5.4.0
 jsonschema = 4.4.0
 lockfile = 0.12.2
 markdown = 3.3.4

--- a/versions.cfg
+++ b/versions.cfg
@@ -24,12 +24,12 @@ nt-svcutils = 2.13.0
 
 # recipes and extensions
 buildout.requirements = 0.2.2
-cachecontrol = 0.12.6
-click = 8.0.1
+cachecontrol = 0.12.10
+click = 8.0.4
 click-default-group = 1.2.2
 collective.recipe.omelette = 1.1.0
-collective.recipe.vscode = 0.1.7
-Genshi = 0.7.5
+collective.recipe.vscode = 0.1.8
+Genshi = 0.7.6
 incremental = 21.3.0
 plone.recipe.alltests = 1.5.2
 plone.recipe.precompiler = 0.7.2
@@ -37,7 +37,7 @@ plone.recipe.zeoserver = 2.0.3
 plone.recipe.zope2instance = 6.10.2
 plone.releaser = 1.8.6
 plone.versioncheck = 1.7.0
-python-dotenv = 0.19.0
+python-dotenv = 0.19.2
 towncrier = 19.2.0
 z3c.template = 3.1.0
 zest.releaser = 7.0.0a1
@@ -88,8 +88,7 @@ zope.mkzeoinstance = 4.1
 zope.password = 4.3.1
 
 # Newer versions than from the current Zope 5.x. Remove after Zope updates it.
-# nothing yet
-zope.i18n = 4.8.0
+zope.i18n = 4.9.0
 Products.ZCatalog = 6.1
 collective.recipe.template = 2.2
 
@@ -98,16 +97,16 @@ zope.component = 4.6.2
 
 ##############################################################################
 # External dependencies
-calmjs.parse = 1.2.5
+calmjs.parse = 1.3.0
 cssselect = 1.1.0
-decorator = 5.0.9
+decorator = 5.1.1
 enum34 = 1.1.10
 feedparser = 6.0.8
 functools32 = 3.2.3.post2
 futures = 3.3.0
 interlude = 1.3.1
 gunicorn = 20.1.0
-jsonschema = 3.2.0
+jsonschema = 4.4.0
 lockfile = 0.12.2
 markdown = 3.3.4
 olefile = 0.46
@@ -116,16 +115,16 @@ pathlib = 1.0.1
 piexif = 1.1.3
 pillow = 9.0.1
 pyjwt = 1.7.1
-pyrsistent = 0.18.0
-pyscss = 1.3.7
+pyrsistent = 0.18.1
+pyscss = 1.4.0
 python-dateutil = 2.8.2
 repoze.xmliter = 0.6.1
 sgmllib3k = 1.0.0
-simplejson = 3.17.3
+simplejson = 3.17.6
+unidecode = 1.2.0
 
 # Special pins, see annotations
 ply = 3.11
-unidecode = 1.2.0
 
 ##############################################################################
 # Plone release
@@ -136,7 +135,7 @@ diazo                                 = 1.4.2
 five.customerize                      = 2.0.1
 five.intid                            = 1.2.6
 icalendar                             = 4.0.9
-jq                                    = 1.2.1
+jq                                    = 1.2.2
 mockup                                = 4.0.2
 Plone                                 = 6.0.0a3
 plone.alterego                        = 1.1.5
@@ -205,7 +204,7 @@ plone.registry                        = 1.2.1
 plone.reload                          = 3.0.2
 plone.resource                        = 2.1.4
 plone.rest                            = 2.0.0a3
-plone.restapi                         = 8.21.0
+plone.restapi                         = 8.21.2
 plone.resourceeditor                  = 3.0.3
 plone.rfc822                          = 2.0.2
 plone.scale                           = 4.0.0a1
@@ -230,7 +229,6 @@ Products.CMFEditions                  = 4.0.0a3
 Products.CMFPlacefulWorkflow          = 3.0.0a1
 Products.CMFPlone                     = 6.0.0a3
 Products.CMFUid                       = 3.2.0
-Products.contentmigration             = 2.2.1
 Products.DateRecurringIndex           = 3.0.1
 Products.DCWorkflow                   = 2.5.0
 Products.ExtendedPathIndex            = 4.0.1
@@ -294,41 +292,42 @@ plone.jsonserializer                  = 0.9.10
 # We said they were not part of the release, but should still be pinned
 # so our development builds are repeatable.
 # But real dependencies creep in anyway, like cryptography that is pulled in by restapi.
-argcomplete = 1.12.3
+argcomplete = 2.0.0
 argh = 0.26.2
-build = 0.1.0
+build = 0.7.0
 cached-property = 1.5.2
-check-manifest = 0.46
-Deprecated = 1.2.12
-distro = 1.6.0
+check-manifest = 0.47
+Deprecated = 1.2.13
+distro = 1.7.0
 fancycompleter = 0.9.1
 FormEncode = 2.0.1
-gitdb2 = 2.0.6
-gitpython = 3.0.5
+gitdb = 4.0.9
+gitdb2 = 4.0.2
+gitpython = 3.1.27
 html5lib = 1.1
-httplib2 = 0.20.2
-launchpadlib = 1.10.13
-lazr.restfulclient = 0.14.3
-lazr.uri = 1.0.5
-oauthlib = 3.1.1
+httplib2 = 0.20.4
+launchpadlib = 1.10.16
+lazr.restfulclient = 0.14.4
+lazr.uri = 1.0.6
+oauthlib = 3.2.0
 pdbpp = 0.10.3
-pep517 = 0.11.0
+pep517 = 0.12.0
 progress = 1.6
 prompt-toolkit = 1.0.18
 PyGithub = 1.47
 pyrepl = 0.9.0
 pyroma = 3.2
-pynacl = 1.4.0
-smmap = 3.0.4
+pynacl = 1.5.0
+smmap = 5.0.0
 smmap2 = 3.0.1
 stdlib-list = 0.8.0
 testresources = 2.0.1
-tomli = 1.2.2
-typing-extensions = 3.10.0.0
-wadllib = 1.3.5
+tomli = 2.0.1
+typing-extensions = 4.1.1
+wadllib = 1.3.6
 wcwidth = 0.2.5
 wmctrl = 0.4
-wrapt = 1.12.1
+wrapt = 1.13.3
 z3c.dependencychecker = 2.7
 zest.pocompile = 1.5.0
 
@@ -345,7 +344,5 @@ robotframework =
     Since 3.2.x the robot.parsing module API has breaking changes, thus we need to adopt before upgrading.
 smmap2 =
     Needs to be a 2 series
-Unidecode =
-    Unidecode 0.04.{2-9} breaks tests
 zope.component =
     5.0.0 causes a few problems.  See https://github.com/plone/buildout.coredev/pull/725#issuecomment-872272811


### PR DESCRIPTION
With help from `bin/versioncheck`.
We may want to actually remove some.

Removed `Products.contentmigration` because it is Python 2 only.