### PR TITLE
Updated package versions, removed several unused ones. [6.0]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-setuptools==62.0.0
+setuptools==62.1.0
 zc.buildout==3.0.0rc3
 pip==22.0.4
 wheel==0.37.1

--- a/versions.cfg
+++ b/versions.cfg
@@ -14,7 +14,7 @@ extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.
 
 # Basics
 # !! keep in sync with requirements.txt !!
-setuptools = 62.0.0
+setuptools = 62.1.0
 zc.buildout = 3.0.0rc3
 pip = 22.0.4
 wheel = 0.37.1
@@ -23,7 +23,6 @@ wheel = 0.37.1
 nt-svcutils = 2.13.0
 
 # recipes and extensions
-buildout.requirements = 0.2.2
 cachecontrol = 0.12.10
 click = 8.0.4
 click-default-group = 1.2.2
@@ -38,7 +37,7 @@ plone.recipe.zeoserver = 2.0.3
 plone.recipe.zope2instance = 6.11.0
 plone.releaser = 1.8.6
 plone.versioncheck = 1.7.0
-python-dotenv = 0.19.2
+python-dotenv = 0.20.0
 towncrier = 19.2.0
 z3c.template = 3.1.0
 zest.releaser = 7.0.0a3
@@ -81,10 +80,10 @@ ZODB3 = 3.11.0
 zope.app.intid = 3.7.1
 zope.app.locales = 4.1
 zope.copy = 4.2
-zope.copypastemove = 4.1.0
+zope.copypastemove = 4.2.0
 zope.dublincore = 4.3.0
 zope.intid = 4.4.0
-zope.keyreference = 4.2.0
+zope.keyreference = 5.0.0
 zope.mkzeoinstance = 4.1
 zope.password = 4.3.1
 
@@ -92,7 +91,6 @@ zope.password = 4.3.1
 
 ##############################################################################
 # External dependencies
-calmjs.parse = 1.3.0
 cssselect = 1.1.0
 decorator = 5.1.1
 enum34 = 1.1.10
@@ -100,10 +98,10 @@ feedparser = 6.0.8
 functools32 = 3.2.3.post2
 interlude = 1.3.1
 gunicorn = 20.1.0
-importlib-resources = 5.4.0
+importlib-resources = 5.6.0
 jsonschema = 4.4.0
 lockfile = 0.12.2
-markdown = 3.3.4
+markdown = 3.3.6
 olefile = 0.46
 ordereddict = 1.1
 pathlib = 1.0.1
@@ -111,21 +109,16 @@ piexif = 1.1.3
 pillow = 9.0.1
 pyjwt = 1.7.1
 pyrsistent = 0.18.1
-pyscss = 1.4.0
 python-dateutil = 2.8.2
 repoze.xmliter = 0.6.1
 sgmllib3k = 1.0.0
 simplejson = 3.17.6
-unidecode = 1.2.0
+unidecode = 1.3.4
 webresource = 1.0
-
-# Special pins, see annotations
-ply = 3.11
 
 ##############################################################################
 # Plone release
 borg.localrole                        = 3.1.8
-collective.folderishtypes             = 3.0.0
 collective.monkeypatcher              = 1.2.1
 diazo                                 = 1.4.2
 five.customerize                      = 2.0.1
@@ -216,7 +209,7 @@ plone.testing                         = 8.0.3
 plone.theme                           = 3.0.7
 plone.transformchain                  = 2.0.2
 plone.uuid                            = 1.0.6
-plone.volto                           = 4.0.0a3
+plone.volto                           = 4.0.0a4
 plone.z3cform                         = 2.0.0a2
 plonetheme.barceloneta                = 3.0.0a11
 Products.CMFCore                      = 2.5.4
@@ -234,7 +227,6 @@ Products.GenericSetup                 = 2.2.0
 Products.isurlinportal                = 1.2.1
 Products.MimetypesRegistry            = 2.1.9
 Products.PlonePAS                     = 7.0.0a3
-Products.PloneTestCase                = 0.9.18
 Products.PluggableAuthService         = 2.7.0
 Products.PluginRegistry               = 1.9
 Products.PortalTransforms             = 3.2.0
@@ -246,7 +238,6 @@ Products.validation                   = 2.1.3
 Products.ZopeVersionControl           = 2.0.0
 Products.ZSQLMethods                  = 3.14
 sourcecodegen                         = 0.6.14
-z3c.autoinclude                       = 0.4.1
 z3c.caching                           = 2.2
 z3c.form                              = 4.3
 z3c.formwidget.query                  = 0.17
@@ -256,8 +247,7 @@ zodbverify                            = 1.1.0
 
 ##############################################################################
 # Ecosystem (not officially part of core)
-collective.js.jqueryui                = 2.1.8
-collective.z3cform.datagridfield      = 2.0.1
+collective.z3cform.datagridfield      = 2.0.2
 collective.z3cform.datetimewidget     = 1.2.9
 plone.app.debugtoolbar                = 1.2.3
 plone.app.relationfield               = 3.0.0a1
@@ -293,7 +283,7 @@ argcomplete = 2.0.0
 argh = 0.26.2
 build = 0.7.0
 cached-property = 1.5.2
-check-manifest = 0.47
+check-manifest = 0.48
 Deprecated = 1.2.13
 distro = 1.7.0
 fancycompleter = 0.9.1
@@ -311,19 +301,18 @@ pdbpp = 0.10.3
 pep517 = 0.12.0
 progress = 1.6
 prompt-toolkit = 1.0.18
-PyGithub = 1.47
+PyGithub = 1.54.1
 pyrepl = 0.9.0
-pyroma = 3.2
+pyroma = 3.3
 pynacl = 1.5.0
 smmap = 5.0.0
-smmap2 = 3.0.1
 stdlib-list = 0.8.0
 testresources = 2.0.1
 tomli = 2.0.1
 wadllib = 1.3.6
 wcwidth = 0.2.5
 wmctrl = 0.4
-wrapt = 1.13.3
+wrapt = 1.14.0
 z3c.dependencychecker = 2.7
 zest.pocompile = 1.5.0
 
@@ -393,13 +382,11 @@ zipp = 3.6.0
 # keep this alphabetical please
 prompt-toolkit =
     Requirement of robotframework-debuglibrary: prompt-toolkit<2
-ply =
-    3.4 previously pinned for slimit, but calmjs.parse needs 3.6+, though it comes with pre-generated tab files for up to 3.11. See https://github.com/dabeaz/ply/issues/82,
 pyjwt =
-    plone.restapi fails with PyJWT >=2 - see https://github.com/plone/plone.restapi/issues/1193
+    plone.restapi fails with PyJWT >=2 - see https://github.com/plone/plone.restapi/issues/1193 and see PyGithub version annotation
+PyGithub =
+    PyGutHub 1.55+ requires PyJWT >= 2, which plone.restapi fails with, see pyjwt version annotation
 robotframework =
     Since 3.2.x the robot.parsing module API has breaking changes, thus we need to adopt before upgrading.
-setuptools =
-    60+ does not work with buildout 3, throwing a TypeError: dist must be a Distribution instance
-smmap2 =
-    Needs to be a 2 series
+Pillow =
+    9.1.0 gives a test failure in plone.scale due to an extra DeprecationWarning.  See https://github.com/plone/plone.scale/issues/49


### PR DESCRIPTION
I started doing this before https://github.com/zopefoundation/Zope/pull/1028 was merged, but was too late.

Since that merge, I copied over the removed Zope versions directly in the 6.0 branch, to fix the build. We can remove more version pins from there.

But here is some initial cleanup. Note: also includes a `setuptools` increase, so you may want to run `bin/pip install --force-reinstall -r requirements.txt`