### PR TITLE
Products.ZCatalog=5.4 in Plone 5.2

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -89,6 +89,7 @@ zope.password = 4.3.1
 
 # Older/newer versions than pinned in Zope.  Remove only if we are sure Zope has has a good version now.
 # Each pin should have a comment in versionannotations below.
+Products.ZCatalog = 5.4
 zope.component = 4.6.2
 
 ##############################################################################
@@ -430,3 +431,5 @@ Unidecode =
     Unidecode 0.04.{2-9} breaks tests
 zope.component =
     5.0.0 causes a few problems.  See https://github.com/plone/buildout.coredev/pull/725#issuecomment-872272811
+Products.ZCatalog =
+    5.4 is not pinned in current Zope version 4.8.1. First step to fix https://github.com/plone/Products.CMFPlone/issues/3432


### PR DESCRIPTION
`Products.ZCatalog` 5.4 is not pinned in current Zope version `4.8.1`. First step to fix https://github.com/plone/Products.CMFPlone/issues/3432.