### PR TITLE
Products.ZCatalog=6.2

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -156,6 +156,7 @@ Products.PythonScripts = 4.13
 Products.Sessions = 4.12
 Products.SiteErrorLog = 5.5
 Products.StandardCacheManagers = 4.1.1
+Products.ZCatalog = 6.2
 Products.ZopeVersionControl = 2.0.0
 repoze.xmliter = 0.6.1
 z3c.caching = 2.2
@@ -227,3 +228,5 @@ robotframework =
     Since 3.2.x the robot.parsing module API has breaking changes, thus we need to adopt before upgrading.
 Pillow =
     9.1.0 gives a test failure in plone.scale due to an extra DeprecationWarning.  See https://github.com/plone/plone.scale/issues/49
+Products.ZCatalog =
+    6.2 is not pinned in current Zope version 5.5.1. First step to fix https://github.com/plone/Products.CMFPlone/issues/3432


### PR DESCRIPTION
`Products.ZCatalog` 6.2 is not pinned in current Zope version 5.5.1. First step to fix plone/Products.CMFPlone#3432 in Plone 6