### PR TITLE
Upgrade to robotframework 3.2, using robotsuite 2.3.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -166,6 +166,7 @@ Products.statusmessages             = git ${remotes:plone}/Products.statusmessag
 Products.validation                 = git ${remotes:plone}/Products.validation.git pushurl=${remotes:plone_push}/Products.validation.git branch=master
 Products.ZopeVersionControl         = git ${remotes:zope}/Products.ZopeVersionControl.git pushurl=${remotes:zope_push}/Products.ZopeVersionControl.git branch=master
 repoze.xmliter                      = git https://github.com/repoze/repoze.xmliter.git pushurl=git@github.com:repoze/repoze.xmliter.git branch=master
+robotsuite                          = git ${remotes:collective}/robotsuite.git pushurl=${remotes:collective_push}/robotsuite.git
 z3c.autoinclude                     = git ${remotes:zope}/z3c.autoinclude.git pushurl=${remotes:zope_push}/z3c.autoinclude.git branch=master
 z3c.batching                        = git ${remotes:zope}/z3c.batching.git pushurl=${remotes:zope_push}/z3c.batching.git branch=master
 z3c.caching                         = git ${remotes:zope}/z3c.caching.git pushurl=${remotes:zope_push}/z3c.caching.git branch=master

--- a/versions.cfg
+++ b/versions.cfg
@@ -207,14 +207,14 @@ zipp = 3.8.0
 # See also the version annotations.
 # Kept separately for the moment, because they probably need to be updated together.
 # Move them in the 'other' section later.
-robotframework = 3.1.2
+robotframework = 3.2.2
 robotframework-python3 = 2.9
 robotframework-debuglibrary = 1.2.1
 robotframework-ride = 1.7.4.1
 robotframework-seleniumlibrary = 3.3.1
 robotframework-selenium2library = 3.0.0
 robotframework-selenium2screenshots = 0.8.1
-robotsuite = 2.2.1
+robotsuite = 2.3.0
 selenium = 3.141.0
 
 
@@ -224,8 +224,6 @@ prompt-toolkit =
     Requirement of robotframework-debuglibrary: prompt-toolkit<2
 pyjwt =
     plone.restapi fails with PyJWT >=2 - see https://github.com/plone/plone.restapi/issues/1193 and see PyGithub version annotation in versions-extra.cfg
-robotframework =
-    Since 3.2.x the robot.parsing module API has breaking changes, thus we need to adopt before upgrading.
 Pillow =
     9.1.0 gives a test failure in plone.scale due to an extra DeprecationWarning.  See https://github.com/plone/plone.scale/issues/49
 Products.ZCatalog =


### PR DESCRIPTION
We may be able to do a much larger version upgrade, see `plips/plip-robotframework.cfg`, but this is an important first step.

See https://github.com/collective/robotsuite/pull/23 for the changes that Asko merged today.