### PR TITLE
GHA: run on Python 3.10.

### DIFF
--- a/.github/workflows/run-buildout.yml
+++ b/.github/workflows/run-buildout.yml
@@ -10,6 +10,7 @@ jobs:
         - "3.7"
         - "3.8"
         - "3.9"
+        - "3.10"
         os:
         - ubuntu-latest
         - windows-latest


### PR DESCRIPTION
Latest run on [Jenkins is green](https://jenkins.plone.org/job/plone-6.0-python-3.10/265/).