### PR TITLE
Move ecosystem sources to ecosystem.cfg.

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -18,7 +18,6 @@ auto-checkout =
     plonetheme.barceloneta
     plone.restapi
     plone.staticresources
-    plone.app.mosaic
     plone.scale
     plone.namedfile
     plone.schemaeditor

--- a/ecosystem.cfg
+++ b/ecosystem.cfg
@@ -30,3 +30,9 @@ test-eggs =
     ${:custom-eggs}
     collective.z3cform.datagridfield[test]
     plone.app.mosaic[test]
+
+[sources]
+plone.app.mosaic                    = git ${remotes:plone}/plone.app.mosaic.git pushurl=${remotes:plone_push}/plone.app.mosaic.git branch=es6
+collective.z3cform.datagridfield    = git ${remotes:collective}/collective.z3cform.datagridfield.git pushurl=${remotes:collective_push}/collective.z3cform.datagridfield.git branch=master
+plone.app.debugtoolbar              = git ${remotes:plone}/plone.app.debugtoolbar.git pushurl=${remotes:plone_push}/plone.app.debugtoolbar.git branch=master
+Products.PDBDebugMode               = git ${remotes:collective}/Products.PDBDebugMode.git pushurl=${remotes:collective_push}/Products.PDBDebugMode.git branch=master

--- a/sources.cfg
+++ b/sources.cfg
@@ -38,7 +38,6 @@ borg.localrole                      = git ${remotes:plone}/borg.localrole.git pu
 collective.monkeypatcher            = git ${remotes:plone}/collective.monkeypatcher.git pushurl=${remotes:plone_push}/collective.monkeypatcher.git branch=master
 collective.recipe.omelette          = git ${remotes:collective}/collective.recipe.omelette.git pushurl=${remotes:collective_push}/collective.recipe.omelette.git branch=master
 collective.xmltestreport            = git ${remotes:collective}/collective.xmltestreport.git pushurl=${remotes:collective_push}/collective.xmltestreport.git branch=master
-collective.z3cform.datagridfield    = git ${remotes:collective}/collective.z3cform.datagridfield.git pushurl=${remotes:collective_push}/collective.z3cform.datagridfield.git branch=master
 diazo                               = git ${remotes:plone}/diazo.git pushurl=${remotes:plone_push}/diazo.git branch=master
 five.customerize                    = git ${remotes:zope}/five.customerize.git pushurl=${remotes:zope_push}/five.customerize.git branch=master
 five.intid                          = git ${remotes:plone}/five.intid.git pushurl=${remotes:plone_push}/five.intid.git branch=master
@@ -55,7 +54,6 @@ plone.app.contentmenu               = git ${remotes:plone}/plone.app.contentmenu
 plone.app.contentrules              = git ${remotes:plone}/plone.app.contentrules.git pushurl=${remotes:plone_push}/plone.app.contentrules.git branch=master
 plone.app.contenttypes              = git ${remotes:plone}/plone.app.contenttypes.git pushurl=${remotes:plone_push}/plone.app.contenttypes.git branch=master
 plone.app.customerize               = git ${remotes:plone}/plone.app.customerize.git pushurl=${remotes:plone_push}/plone.app.customerize.git branch=master
-plone.app.debugtoolbar              = git ${remotes:plone}/plone.app.debugtoolbar.git pushurl=${remotes:plone_push}/plone.app.debugtoolbar.git branch=master
 plone.app.dexterity                 = git ${remotes:plone}/plone.app.dexterity.git pushurl=${remotes:plone_push}/plone.app.dexterity.git branch=master
 plone.app.discussion                = git ${remotes:plone}/plone.app.discussion.git pushurl=${remotes:plone_push}/plone.app.discussion.git branch=master
 plone.app.event                     = git ${remotes:plone}/plone.app.event.git pushurl=${remotes:plone_push}/plone.app.event.git branch=master
@@ -66,7 +64,6 @@ plone.app.layout                    = git ${remotes:plone}/plone.app.layout.git 
 plone.app.linkintegrity             = git ${remotes:plone}/plone.app.linkintegrity.git pushurl=${remotes:plone_push}/plone.app.linkintegrity.git branch=master
 plone.app.locales                   = git ${remotes:collective}/plone.app.locales.git pushurl=${remotes:collective_push}/plone.app.locales.git branch=master
 plone.app.lockingbehavior           = git ${remotes:plone}/plone.app.lockingbehavior.git pushurl=${remotes:plone_push}/plone.app.lockingbehavior.git branch=master
-plone.app.mosaic                    = git ${remotes:plone}/plone.app.mosaic.git pushurl=${remotes:plone_push}/plone.app.mosaic.git branch=es6
 plone.app.multilingual              = git ${remotes:plone}/plone.app.multilingual.git pushurl=${remotes:plone_push}/plone.app.multilingual.git branch=master
 plone.app.portlets                  = git ${remotes:plone}/plone.app.portlets.git pushurl=${remotes:plone_push}/plone.app.portlets.git branch=master
 plone.app.querystring               = git ${remotes:plone}/plone.app.querystring.git pushurl=${remotes:plone_push}/plone.app.querystring.git branch=master
@@ -156,7 +153,6 @@ Products.ExternalMethod             = git ${remotes:zope}/Products.ExternalMetho
 Products.GenericSetup               = git ${remotes:zope}/Products.GenericSetup.git pushurl=${remotes:zope_push}/Products.GenericSetup.git branch=master
 Products.isurlinportal              = git ${remotes:plone}/Products.isurlinportal.git pushurl=${remotes:plone_push}/Products.isurlinportal.git branch=master
 Products.MimetypesRegistry          = git ${remotes:plone}/Products.MimetypesRegistry.git pushurl=${remotes:plone_push}/Products.MimetypesRegistry.git branch=master
-Products.PDBDebugMode               = git ${remotes:collective}/Products.PDBDebugMode.git pushurl=${remotes:collective_push}/Products.PDBDebugMode.git branch=master
 Products.PlacelessTranslationService= git ${remotes:plone}/Products.PlacelessTranslationService.git pushurl=${remotes:plone_push}/Products.PlacelessTranslationService.git branch=master
 Products.PlonePAS                   = git ${remotes:plone}/Products.PlonePAS.git pushurl=${remotes:plone_push}/Products.PlonePAS.git branch=master
 Products.PluggableAuthService       = git ${remotes:zope}/Products.PluggableAuthService.git pushurl=${remotes:zope_push}/Products.PluggableAuthService.git branch=master

--- a/versions-extra.cfg
+++ b/versions-extra.cfg
@@ -56,7 +56,6 @@ twine = 4.0.0
 wadllib = 1.3.6
 webencodings = 0.5.1
 wmctrl = 0.4
-wrapt = 1.14.0
 z3c.dependencychecker = 2.7
 zest.pocompile = 1.5.0
 zest.releaser = 7.0.0a3

--- a/versions.cfg
+++ b/versions.cfg
@@ -223,6 +223,7 @@ watchdog = 2.1.7
 wcwidth = 0.2.5
 webresource = 1.0
 wsproto = 1.1.0
+wrapt = 1.14.0
 zipp = 3.8.0
 
 [versionannotations]


### PR DESCRIPTION
Currenly, any commit to plone.app.mosaic results in a fake commit in coredev and runs Jenkins jobs.
Also: remove plone.app.mosaic from checkouts.