### PR TITLE
Exclude MacOs on 3.10 on gh-actions.

### DIFF
--- a/.github/workflows/run-buildout.yml
+++ b/.github/workflows/run-buildout.yml
@@ -15,6 +15,10 @@ jobs:
         - ubuntu-latest
         - windows-latest
         - macos-latest
+        exclude:
+        # MacOS on gh-actions cannot install MarkupSafe on Py 3.10, see https://github.com/plone/buildout.coredev/issues/799
+        - os: macos-latest
+          python-version: "3.10"
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Fails installing MarkupSafe.  Works fine locally.
See https://github.com/plone/buildout.coredev/issues/799