### PR TITLE
Remove pin of pyroma

### DIFF
--- a/versions-extra.cfg
+++ b/versions-extra.cfg
@@ -44,7 +44,6 @@ PyGithub = 1.55
 PyNaCl = 1.5.0
 pyparsing = 3.0.9
 pyrepl = 0.9.0
-pyroma = 4.0b2
 readme-renderer = 35.0
 requests-toolbelt = 0.9.1
 rfc3986 = 2.0.0


### PR DESCRIPTION
This avoids conflict with the pinned version in [plone/code-quality](https://github.com/plone/code-quality/blob/bbf51a8fde8d557269d0eda7fe500530acb23b06/requirements.txt#L7).

I have a Makefile with the following line:

```
bin/pip install -r https://raw.githubusercontent.com/plone/code-quality/v$(CODE_QUALITY_VERSION)/requirements.txt -c https://dist.plone.org/release/$(PLONE6)/constraints.txt
```
This leads to a conflict error in pip:

```
ERROR: Cannot install pyroma==4.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested pyroma==4.0
    The user requested (constraint) pyroma==4.0b2
```

I put the Plone dependencies because in the end they are the ones that will be valid. This avoids reinstalling package versions, making `make build` more faster.

I don't see `pyroma` being installed on coredev. And usually Plone constraints don't pin "lint packages".

Do I need to remove the [constraints.txt](https://github.com/plone/buildout.coredev/blob/6.0/release/constraints.txt) pin as well?
