### PR TITLE
gh-actions on 6.0: upgrade Python versions.

### DIFF
--- a/.github/workflows/bare.yml
+++ b/.github/workflows/bare.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         python-version:
         # Use the oldest supported Python version, as that may pull in more versions.
-        - "3.7"
+        - "3.8"
     runs-on: ubuntu-latest
     steps:
     - name: locale

--- a/.github/workflows/ecosystem.yml
+++ b/.github/workflows/ecosystem.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - "3.9"
+        - "3.10"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/run-buildout.yml
+++ b/.github/workflows/run-buildout.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"


### PR DESCRIPTION
For the bare job, use Python 3.8.
For ecosystem use 3.10.
For run-buildout, remove 3.7.