### PR TITLE
Downgrade pip, upgrade setuptools.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
-setuptools==63.2.0
-zc.buildout==3.0.0rc3
-pip==22.2
+# With pip>=22.2, buildout fails to check the python-requires of a package,
+# so you may get incompatible versions.
+# See https://github.com/buildout/buildout/issues/613
+# So we pin an older one.
+pip==22.1.2
+setuptools==65.4.1
 wheel==0.37.1
+zc.buildout==3.0.0rc3
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -13,10 +13,10 @@ extends = https://zopefoundation.github.io/Zope/releases/5.6/versions.cfg
 [versions]
 # Basics
 # !! keep in sync with requirements.txt !!
-setuptools = 63.2.0
-zc.buildout = 3.0.0rc3
-pip = 22.2
+pip = 22.1.2
+setuptools = 65.4.1
 wheel = 0.37.1
+zc.buildout = 3.0.0rc3
 
 # windows specific
 nt-svcutils = 2.13.0


### PR DESCRIPTION
With `pip>=22.2` that we have been using, buildout fails to check the python-requires of a package, so you may get incompatible versions. See https://github.com/buildout/buildout/issues/613 A fix is underway, but that can take a while.
So downgrade pip to 21.
Do try the latest setuptools.

The error you get is:

```
$ bin/buildout
Requires-Python support missing.

Traceback (most recent call last):
  File "/Users/maurits/community/plone-coredev/6.0/lib/python3.10/site-packages/zc/buildout/patches.py", line 52, in patch_PackageIndex
    from pip._internal.index.collector import HTMLPage
ImportError: cannot import name 'HTMLPage' from 'pip._internal.index.collector' (/Users/maurits/shared-eggs/cp310/pip-22.2-py3.10.egg/pip/_internal/index/collector.py)
```

Buildout *does* continue after that, but as said: it is missing the python-requires functionality.