### PR TITLE
Prepare for new icalendar release

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -8,7 +8,6 @@ test-eggs =
     diazo [test]
     five.customerize
     five.intid
-    icalendar
     plone.alterego
     plone.api [test]
     plone.app.caching [test]

--- a/versions.cfg
+++ b/versions.cfg
@@ -136,7 +136,7 @@ collective.recipe.vscode = 0.1.8
 collective.MockMailHost = 2.0.0
 collective.monkeypatcher = 1.2.1
 collective.xmltestreport = 2.0.2
-icalendar = 5.0.0a1
+icalendar = 5.0.0
 Products.DateRecurringIndex = 3.0.1
 robotsuite = 2.3.1
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -225,6 +225,9 @@ wsproto = 1.1.0
 wrapt = 1.14.1
 zipp = 3.8.1
 
+[versions:python38]
+backports.zoneinfo = 0.2.1
+
 [versionannotations]
 # keep this alphabetical please
 prompt-toolkit =


### PR DESCRIPTION
I want to see if anything breaks before a new icalendar release is out. See https://github.com/collective/icalendar/issues/429