### PR TITLE
Upgrade lxml pin to 4.9.1.

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -186,7 +186,7 @@ h11 = 0.13.0
 importlib-metadata = 4.12.0
 importlib-resources = 5.8.1
 jsonschema = 4.7.2
-lxml = 4.8.0
+lxml = 4.9.1
 manuel = 1.12.4
 Markdown = 3.4.1
 orderedmultidict = 1.0.1
@@ -232,5 +232,3 @@ backports.zoneinfo = 0.2.1
 # keep this alphabetical please
 prompt-toolkit =
   Requirement of robotframework-debuglibrary: prompt-toolkit<3,>=2
-lxml =
-  lxml 4.9.0 and 4.9.1 give two errors in Products/PortalTransforms/tests/test_xss.py


### PR DESCRIPTION
For me this makes the buildout finish on Python 3.11, which is very nice! Previously though, I saw that lxml 4.9.0 and 4.9.1 give two errors in `Products/PortalTransforms/tests/test_xss.py`. Locally I did not see these, only on Jenkins.  Let's try again.