### PR TITLE
gh-actions on 5.2: run on ubuntu-20.04.

### DIFF
--- a/.github/workflows/run-buildout.yml
+++ b/.github/workflows/run-buildout.yml
@@ -12,7 +12,7 @@ jobs:
         - "3.7"
         - "3.8"
         os:
-        - ubuntu-latest
+        - ubuntu-20.04
         - windows-latest
         - macos-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run-buildout.yml
+++ b/.github/workflows/run-buildout.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         sudo locale-gen nl_NL@euro
         sudo update-locale
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-20.04'
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3


### PR DESCRIPTION
We used ubuntu-latest, but this now points to 22.04, and the github image does not have Python 2.7 installed. See failed run:
https://github.com/plone/buildout.coredev/actions/runs/3600952925/jobs/6066191719#step:4:7

cc @fredvd who [fixed this in easyform 3.x](https://github.com/collective/collective.easyform/commit/09118b066d8452d80daa73bbe58958705059b22b) yesterday.