### PR TITLE
Checkout Zope, extend Zope master versions.

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -9,5 +9,6 @@ auto-checkout =
     Products.CMFPlone
     mockup
     docs
+    Zope
 # These packages are manually added, or automatically added by mr.roboto:
     plone.formwidget.recurrence

--- a/versions.cfg
+++ b/versions.cfg
@@ -5,9 +5,9 @@
 # Note: version pins in this file should only be removed in a new minor version of Plone.
 
 # Based on latest development Zope:
-# extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
+extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
 # Based on released Zope:
-extends = https://zopefoundation.github.io/Zope/releases/5.7/versions.cfg
+# extends = https://zopefoundation.github.io/Zope/releases/5.7/versions.cfg
 
 
 [versions]
@@ -22,11 +22,6 @@ zc.buildout = 3.0.1
 nt-svcutils = 2.13.0
 
 # OVERRIDES
-certifi = 2022.12.7
-zdaemon = 4.4
-zope.location = 4.3
-zope.security = 5.8
-ZConfig = 3.6.1
 
 # CORE PLONE.
 # These packages are what you get when installing Plone plus test dependencies,


### PR DESCRIPTION
The Zope code has no changes yet.
We usually have it checked out, but I had switched this off a while before the final release, so we really tested with a Zope release.