### PR TITLE
Tests for http response content type fix.

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -9,7 +9,12 @@ auto-checkout =
     Products.CMFPlone
     mockup
     docs
+# These checkouts are needed for https://github.com/zopefoundation/Zope/pull/1075/files
     Zope
+    plone.protect
+    plone.app.testing
+    plone.cachepurging
+    plone.testing
 # These packages are manually added, or automatically added by mr.roboto:
     plone.formwidget.recurrence
     plone.volto

--- a/sources.cfg
+++ b/sources.cfg
@@ -107,7 +107,8 @@ plone.outputfilters                 = git ${remotes:plone}/plone.outputfilters.g
 plone.portlet.collection            = git ${remotes:plone}/plone.portlet.collection.git pushurl=${remotes:plone_push}/plone.portlet.collection.git branch=master
 plone.portlet.static                = git ${remotes:plone}/plone.portlet.static.git pushurl=${remotes:plone_push}/plone.portlet.static.git branch=master
 plone.portlets                      = git ${remotes:plone}/plone.portlets.git pushurl=${remotes:plone_push}/plone.portlets.git branch=master
-plone.protect                       = git ${remotes:plone}/plone.protect.git pushurl=${remotes:plone_push}/plone.protect.git branch=master
+# plone.protect                       = git ${remotes:plone}/plone.protect.git pushurl=${remotes:plone_push}/plone.protect.git branch=master
+plone.protect                       = git https://github.com/perrinjerome/plone.protect.git branch=fix/zope_content_type
 plone.recipe.alltests               = git ${remotes:plone}/plone.recipe.alltests.git pushurl=${remotes:plone_push}/plone.recipe.alltests.git branch=master
 plone.recipe.precompiler            = git ${remotes:plone}/plone.recipe.precompiler.git pushurl=${remotes:plone_push}/plone.recipe.precompiler.git branch=master
 plone.recipe.zeoserver              = git ${remotes:plone}/plone.recipe.zeoserver.git pushurl=${remotes:plone_push}/plone.recipe.zeoserver.git branch=master
@@ -171,7 +172,8 @@ z3c.relationfield                   = git ${remotes:zope}/z3c.relationfield.git 
 ZODB3                               = git ${remotes:zope}/ZODB3.git pushurl=${remotes:zope_push}/ZODB3.git branch=master
 zodbupdate                          = git ${remotes:zope}/zodbupdate.git pushurl=${remotes:zope_push}/zodbupdate.git branch=master
 zodbverify                          = git ${remotes:plone}/zodbverify.git pushurl=${remotes:plone_push}/zodbverify.git branch=master
-Zope                                = git ${remotes:zope}/Zope.git pushurl=${remotes:zope_push}/Zope.git branch=master
+# Zope                                = git ${remotes:zope}/Zope.git pushurl=${remotes:zope_push}/Zope.git branch=master
+Zope                                = git https://github.com/perrinjerome/Zope.git branch=fix/http_response_content_type
 
 
 [precompiler]


### PR DESCRIPTION
A change in Zope is being prepared that may need some changes in Plone. See https://github.com/zopefoundation/Zope/pull/1075 There is already a PR for plone.protect needed: https://github.com/plone/plone.protect/pull/97 And from running 'bin/test -u' locally, I see a few more packages will need changes, so I have added them to the checkouts.

Note that for Zope and plone.protect, this PR uses checkouts from repos by @perrinjerome.