### PR TITLE
Use latest setuptools, zc.buildout, wheel, on Python 3 Plone 5.2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,10 @@
-setuptools==42.0.2
-zc.buildout==2.13.8
-wheel==0.37.1
+setuptools==42.0.2; python_version < '3.0'
+zc.buildout==2.13.8; python_version < '3.0'
+wheel==0.37.1; python_version < '3.0'
+
+setuptools==65.7.0; python_version >= '3.0'
+zc.buildout==3.0.1; python_version >= '3.0'
+wheel==0.38.4; python_version >= '3.0'
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -12,10 +12,9 @@ extends = https://zopefoundation.github.io/Zope/releases/4.8.7/versions.cfg
 # Build Tools
 
 # Basics
-# !! keep in sync with requirements.txt !!
-setuptools = 42.0.2
-zc.buildout = 2.13.8
-wheel = 0.37.1
+# For setuptools, zc.buildout, and wheel, see below at versions:python3 and versions:python27.
+# Note that extending this versions.cfg and overriding [versions] still works,
+# without needing to specifically override [versions:python3/27].
 
 # windows specific
 nt-svcutils = 2.13.0
@@ -374,6 +373,12 @@ webencodings = 0.5.1
 zipp = 1.2.0
 
 [versions:python3]
+# !! keep in sync with requirements.txt !!
+setuptools = 65.7.0
+zc.buildout = 3.0.1
+wheel = 0.38.4
+
+# other:
 FormEncode = 2.0.1
 jeepney = 0.8.0
 feedparser = 6.0.8
@@ -385,6 +390,12 @@ typing =
 wxPython = 4.1.1
 
 [versions:python27]
+# !! keep in sync with requirements.txt !!
+setuptools = 42.0.2
+zc.buildout = 2.13.8
+wheel = 0.37.1
+
+# other:
 cachecontrol = 0.12.6
 check-manifest = 0.41
 docutils = 0.15.2


### PR DESCRIPTION
This means we install different versions for these packages on Python 2 and 3.  I don't like this. But some packages are getting harder to install on Python 3 with older versions of these base packages. See my adventures on installing zope.container when I switched from Python 3.8.13 to 3.8.16 on Mac: https://github.com/zopefoundation/zope.container/issues/48 So I think we are better off with the latest versions.

Technically we do not use latest setuptools, which would be 66.0.0. This is very new, and I do not trust the breaking change of no longer supporting versions that do not conform to PEP 440: https://github.com/pypa/setuptools/blob/v66.0.0/CHANGES.rst