### PR TITLE
Update zope branches in sources.cfg. [5.2]

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -1,8 +1,8 @@
 [buildout]
 extends =
     https://raw.githubusercontent.com/zopefoundation/Zope/4.x/sources.cfg
-
-# auto-checkout has moved to checkouts.cfg so it's easier to extend sources.cfg
+# When Zope is in auto-checkout, and you are editing the sources, you want this instead:
+#    src/Zope/sources.cfg
 
 [remotes]
 # (Repository locations)
@@ -20,10 +20,7 @@ collective_push = git@github.com:collective
 zope = https://github.com/zopefoundation
 zope_push = git@github.com:zopefoundation
 
-
-
 [sources]
-AccessControl                       = git ${remotes:zope}/AccessControl.git pushurl=${remotes:zope_push}/AccessControl.git branch=master
 archetypes.multilingual             = git ${remotes:plone}/archetypes.multilingual.git pushurl=${remotes:plone_push}/archetypes.multilingual.git branch=master
 archetypes.referencebrowserwidget   = git ${remotes:plone}/archetypes.referencebrowserwidget.git pushurl=${remotes:plone_push}/archetypes.referencebrowserwidget.git branch=master
 archetypes.schemaextender           = git ${remotes:plone}/archetypes.schemaextender.git pushurl=${remotes:plone_push}/archetypes.schemaextender.git branch=master
@@ -34,8 +31,6 @@ collective.recipe.omelette            = git ${remotes:collective}/collective.rec
 diazo                               = git ${remotes:plone}/diazo.git pushurl=${remotes:plone_push}/diazo.git branch=master
 five.customerize                    = git ${remotes:zope}/five.customerize.git pushurl=${remotes:zope_push}/five.customerize.git branch=master
 five.intid                          = git ${remotes:plone}/five.intid.git pushurl=${remotes:plone_push}/five.intid.git branch=master
-five.localsitemanager               = git ${remotes:zope}/five.localsitemanager.git pushurl=${remotes:zope_push}/five.localsitemanager.git branch=master
-five.pt                             = git ${remotes:zope}/five.pt.git pushurl=${remotes:zope_push}/five.pt.git branch=master
 i18ndude                            = git ${remotes:collective}/i18ndude.git pushurl=${remotes:collective_push}/i18ndude.git branch=master
 icalendar                           = git ${remotes:collective}/icalendar.git pushurl=${remotes:collective_push}/icalendar.git branch=4.x
 jquery.recurrenceinput.js           = git ${remotes:collective}/jquery.recurrenceinput.js.git pushurl=${remotes:collective_push}/jquery.recurrenceinput.js.git branch=master egg=false
@@ -148,19 +143,14 @@ z3c.caching                         = git ${remotes:zope}/z3c.caching.git pushur
 z3c.form                            = git ${remotes:zope}/z3c.form.git pushurl=${remotes:zope_push}/z3c.form.git branch=3.x
 z3c.formwidget.query                = git ${remotes:zope}/z3c.formwidget.query.git pushurl=${remotes:zope_push}/z3c.formwidget.query.git branch=master
 z3c.relationfield                   = git ${remotes:zope}/z3c.relationfield.git pushurl=${remotes:zope_push}/z3c.relationfield.git branch=master
-ZODB3                               = git ${remotes:zope}/ZODB3.git pushurl=${remotes:zope_push}/ZODB3.git branch=master
 zodbupdate                          = git ${remotes:zope}/zodbupdate.git pushurl=${remotes:zope_push}/zodbupdate.git branch=master
 zodbverify                          = git ${remotes:plone}/zodbverify.git pushurl=${remotes:plone_push}/zodbverify.git branch=master
 Zope                                = git ${remotes:zope}/Zope.git pushurl=${remotes:zope_push}/Zope.git branch=4.x
-zope.globalrequest                  = git ${remotes:zope}/zope.globalrequest.git pushurl=${remotes:zope_push}/zope.globalrequest.git branch=master
-zope.sendmail                       = git ${remotes:zope}/zope.sendmail.git pushurl=${remotes:zope_push}/zope.sendmail.git branch=master
-zope.interface                      = git ${remotes:zope}/zope.interface.git pushurl=${remotes:zope_push}/zope.interface.git branch=master
 
 # Products
 Products.Archetypes                 = git ${remotes:plone}/Products.Archetypes.git pushurl=${remotes:plone_push}/Products.Archetypes.git branch=master
 Products.ATContentTypes             = git ${remotes:plone}/Products.ATContentTypes.git pushurl=${remotes:plone_push}/Products.ATContentTypes.git branch=master
-Products.BTreeFolder2               = git ${remotes:zope}/Products.BTreeFolder2.git pushurl=${remotes:zope_push}/Products.BTreeFolder2.git branch=master
-Products.CMFCore                    = git ${remotes:zope}/Products.CMFCore.git pushurl=${remotes:zope_push}/Products.CMFCore.git branch=master
+Products.CMFCore                    = git ${remotes:zope}/Products.CMFCore.git pushurl=${remotes:zope_push}/Products.CMFCore.git branch=2.x
 Products.CMFDiffTool                = git ${remotes:plone}/Products.CMFDiffTool.git pushurl=${remotes:plone_push}/Products.CMFDiffTool.git branch=master
 Products.CMFDynamicViewFTI          = git ${remotes:plone}/Products.CMFDynamicViewFTI.git pushurl=${remotes:plone_push}/Products.CMFDynamicViewFTI.git branch=6.x
 Products.CMFEditions                = git ${remotes:plone}/Products.CMFEditions.git pushurl=${remotes:plone_push}/Products.CMFEditions.git branch=3.x
@@ -168,33 +158,26 @@ Products.CMFFormController          = git ${remotes:plone}/Products.CMFFormContr
 Products.CMFPlacefulWorkflow        = git ${remotes:plone}/Products.CMFPlacefulWorkflow.git pushurl=${remotes:plone_push}/Products.CMFPlacefulWorkflow.git branch=2.x
 Products.CMFPlone                   = git ${remotes:plone}/Products.CMFPlone.git pushurl=${remotes:plone_push}/Products.CMFPlone.git branch=5.2.x
 Products.CMFQuickInstallerTool      = git ${remotes:plone}/Products.CMFQuickInstallerTool.git pushurl=${remotes:plone_push}/Products.CMFQuickInstallerTool.git branch=master
-Products.CMFUid                     = git ${remotes:zope}/Products.CMFUid.git pushurl=${remotes:zope_push}/Products.CMFUid.git branch=master
+Products.CMFUid                     = git ${remotes:zope}/Products.CMFUid.git pushurl=${remotes:zope_push}/Products.CMFUid.git branch=3.x
 Products.contentmigration           = git ${remotes:plone}/Products.contentmigration.git pushurl=${remotes:plone_push}/Products.contentmigration.git branch=master
 Products.DateRecurringIndex         = git ${remotes:collective}/Products.DateRecurringIndex.git pushurl=${remotes:collective_push}/Products.DateRecurringIndex.git branch=master
-Products.DCWorkflow                 = git ${remotes:zope}/Products.DCWorkflow.git pushurl=${remotes:zope_push}/Products.DCWorkflow.git branch=master
+Products.DCWorkflow                 = git ${remotes:zope}/Products.DCWorkflow.git pushurl=${remotes:zope_push}/Products.DCWorkflow.git branch=2.x
 Products.ExtendedPathIndex          = git ${remotes:plone}/Products.ExtendedPathIndex.git pushurl=${remotes:plone_push}/Products.ExtendedPathIndex.git branch=master
 Products.ExternalEditor             = git ${remotes:zope}/Products.ExternalEditor.git pushurl=${remotes:zope_push}/Products.ExternalEditor.git branch=master
-Products.ExternalMethod             = git ${remotes:zope}/Products.ExternalMethod.git pushurl=${remotes:zope_push}/Products.ExternalMethod.git branch=master
-Products.GenericSetup               = git ${remotes:zope}/Products.GenericSetup.git pushurl=${remotes:zope_push}/Products.GenericSetup.git branch=master
+Products.ExternalMethod             = git ${remotes:zope}/Products.ExternalMethod.git pushurl=${remotes:zope_push}/Products.ExternalMethod.git branch=4.x
+Products.GenericSetup               = git ${remotes:zope}/Products.GenericSetup.git pushurl=${remotes:zope_push}/Products.GenericSetup.git branch=2.x
 Products.isurlinportal              = git ${remotes:plone}/Products.isurlinportal.git pushurl=${remotes:plone_push}/Products.isurlinportal.git branch=master
-Products.MailHost                   = git ${remotes:zope}/Products.MailHost.git pushurl=${remotes:zope_push}/Products.MailHost.git branch=master
 Products.Marshall                   = git ${remotes:plone}/Products.Marshall.git pushurl=${remotes:plone_push}/Products.Marshall.git branch=master
 Products.MimetypesRegistry          = git ${remotes:plone}/Products.MimetypesRegistry.git pushurl=${remotes:plone_push}/Products.MimetypesRegistry.git branch=master
 Products.PlacelessTranslationService= git ${remotes:plone}/Products.PlacelessTranslationService.git pushurl=${remotes:plone_push}/Products.PlacelessTranslationService.git branch=master
 Products.PloneLanguageTool          = git ${remotes:plone}/Products.PloneLanguageTool.git pushurl=${remotes:plone_push}/Products.PloneLanguageTool.git branch=master
 Products.PlonePAS                   = git ${remotes:plone}/Products.PlonePAS.git pushurl=${remotes:plone_push}/Products.PlonePAS.git branch=6.x
-Products.PluggableAuthService       = git ${remotes:zope}/Products.PluggableAuthService.git pushurl=${remotes:zope_push}/Products.PluggableAuthService.git branch=master
-Products.PluginRegistry             = git ${remotes:zope}/Products.PluginRegistry.git pushurl=${remotes:zope_push}/Products.PluginRegistry.git branch=master
+Products.PluggableAuthService       = git ${remotes:zope}/Products.PluggableAuthService.git pushurl=${remotes:zope_push}/Products.PluggableAuthService.git branch=2.x
+Products.PluginRegistry             = git ${remotes:zope}/Products.PluginRegistry.git pushurl=${remotes:zope_push}/Products.PluginRegistry.git branch=1.x
 Products.PortalTransforms           = git ${remotes:plone}/Products.PortalTransforms.git pushurl=${remotes:plone_push}/Products.PortalTransforms.git branch=master
-Products.PythonScripts              = git ${remotes:zope}/Products.PythonScripts.git pushurl=${remotes:zope_push}/Products.PythonScripts.git branch=master
-Products.Sessions                   = git ${remotes:zope}/Products.Sessions.git pushurl=${remotes:zope_push}/Products.Sessions.git branch=master
-Products.SiteErrorLog               = git ${remotes:zope}/Products.SiteErrorLog.git pushurl=${remotes:zope_push}/Products.SiteErrorLog.git branch=master
-Products.TemporaryFolder            = git ${remotes:zope}/Products.TemporaryFolder.git pushurl=${remotes:zope_push}/Products.TemporaryFolder.git branch=master
 Products.statusmessages             = git ${remotes:plone}/Products.statusmessages.git pushurl=${remotes:plone_push}/Products.statusmessages.git branch=master
 Products.validation                 = git ${remotes:plone}/Products.validation.git pushurl=${remotes:plone_push}/Products.validation.git branch=master
-Products.ZCatalog                   = git ${remotes:zope}/Products.ZCatalog.git pushurl=${remotes:zope_push}/Products.ZCatalog.git branch=5.x
-Products.ZCTextIndex                = git ${remotes:zope}/Products.ZCTextIndex.git pushurl=${remotes:zope_push}/Products.ZCTextIndex.git branch=2.13
-Products.ZopeVersionControl         = git ${remotes:zope}/Products.ZopeVersionControl.git pushurl=${remotes:zope_push}/Products.ZopeVersionControl.git branch=master
+Products.ZopeVersionControl         = git ${remotes:zope}/Products.ZopeVersionControl.git pushurl=${remotes:zope_push}/Products.ZopeVersionControl.git branch=3.x
 
 [precompiler]
 recipe = plone.recipe.precompiler


### PR DESCRIPTION
A lot of master branches are being updated to drop Python 2.7 support, so we want maintenance branches. I removed several source definitions that were duplicate from the one in Zope/sources.cfg, or that are really not used anymore, like five.pt and ZODB3. I am updating the Zope 4.x sources.cfg as well, and don't want to do this in two places.
Related PR, which would best be merged first: https://github.com/zopefoundation/Zope/pull/1099

I will make the coredev PR a draft PR for now.