### PR TITLE
Checkout PortalTransform 3.x

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -174,7 +174,7 @@ Products.PloneLanguageTool          = git ${remotes:plone}/Products.PloneLanguag
 Products.PlonePAS                   = git ${remotes:plone}/Products.PlonePAS.git pushurl=${remotes:plone_push}/Products.PlonePAS.git branch=6.x
 Products.PluggableAuthService       = git ${remotes:zope}/Products.PluggableAuthService.git pushurl=${remotes:zope_push}/Products.PluggableAuthService.git branch=2.x
 Products.PluginRegistry             = git ${remotes:zope}/Products.PluginRegistry.git pushurl=${remotes:zope_push}/Products.PluginRegistry.git branch=1.x
-Products.PortalTransforms           = git ${remotes:plone}/Products.PortalTransforms.git pushurl=${remotes:plone_push}/Products.PortalTransforms.git branch=master
+Products.PortalTransforms           = git ${remotes:plone}/Products.PortalTransforms.git pushurl=${remotes:plone_push}/Products.PortalTransforms.git branch=3.x
 Products.statusmessages             = git ${remotes:plone}/Products.statusmessages.git pushurl=${remotes:plone_push}/Products.statusmessages.git branch=master
 Products.validation                 = git ${remotes:plone}/Products.validation.git pushurl=${remotes:plone_push}/Products.validation.git branch=master
 Products.ZopeVersionControl         = git ${remotes:zope}/Products.ZopeVersionControl.git pushurl=${remotes:zope_push}/Products.ZopeVersionControl.git branch=3.x


### PR DESCRIPTION
We want to have a 4.x release that depends imports from Products.CMFPlone (which is not listed in the requirements) with imports from plone.base (that will be added to the requirements).