### PR TITLE
Checkout Zope and use its master versions.

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -11,6 +11,7 @@ auto-checkout =
     docs
 # These packages are manually added, or automatically added by mr.roboto:
     Zope
+    plone.formwidget.namedfile
     plone.app.theming
     plone.app.iterate
     plone.app.caching

--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -10,6 +10,7 @@ auto-checkout =
     mockup
     docs
 # These packages are manually added, or automatically added by mr.roboto:
+    Zope
     plone.app.theming
     plone.app.iterate
     plone.app.caching

--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -12,6 +12,7 @@ auto-checkout =
 # These packages are manually added, or automatically added by mr.roboto:
     Zope
     plone.formwidget.namedfile
+    plone.formwidget.recurrence
     plone.app.theming
     plone.app.iterate
     plone.app.caching

--- a/sources.cfg
+++ b/sources.cfg
@@ -93,7 +93,7 @@ plone.contentrules                  = git ${remotes:plone}/plone.contentrules.gi
 plone.dexterity                     = git ${remotes:plone}/plone.dexterity.git pushurl=${remotes:plone_push}/plone.dexterity.git branch=master
 plone.event                         = git ${remotes:plone}/plone.event.git pushurl=${remotes:plone_push}/plone.event.git branch=master
 plone.folder                        = git ${remotes:plone}/plone.folder.git pushurl=${remotes:plone_push}/plone.folder.git branch=master
-plone.formwidget.namedfile          = git ${remotes:plone}/plone.formwidget.namedfile.git pushurl=${remotes:plone_push}/plone.formwidget.namedfile.git branch=master
+plone.formwidget.namedfile          = git ${remotes:plone}/plone.formwidget.namedfile.git pushurl=${remotes:plone_push}/plone.formwidget.namedfile.git branch=maurits-widget-tests-latin-1
 plone.formwidget.recurrence         = git ${remotes:plone}/plone.formwidget.recurrence.git pushurl=${remotes:plone_push}/plone.formwidget.recurrence.git branch=master
 plone.i18n                          = git ${remotes:plone}/plone.i18n.git pushurl=${remotes:plone_push}/plone.i18n.git branch=master
 plone.indexer                       = git ${remotes:plone}/plone.indexer.git pushurl=${remotes:plone_push}/plone.indexer.git branch=master
@@ -168,7 +168,7 @@ z3c.formwidget.query                = git ${remotes:zope}/z3c.formwidget.query.g
 z3c.relationfield                   = git ${remotes:zope}/z3c.relationfield.git pushurl=${remotes:zope_push}/z3c.relationfield.git branch=master
 zodbupdate                          = git ${remotes:zope}/zodbupdate.git pushurl=${remotes:zope_push}/zodbupdate.git branch=master
 zodbverify                          = git ${remotes:plone}/zodbverify.git pushurl=${remotes:plone_push}/zodbverify.git branch=master
-Zope                                = git ${remotes:zope}/Zope.git pushurl=${remotes:zope_push}/Zope.git branch=master
+Zope                                = git ${remotes:zope}/Zope.git pushurl=${remotes:zope_push}/Zope.git branch=maurits-fileupload-charset-latin-1
 
 
 [precompiler]

--- a/sources.cfg
+++ b/sources.cfg
@@ -168,7 +168,7 @@ z3c.formwidget.query                = git ${remotes:zope}/z3c.formwidget.query.g
 z3c.relationfield                   = git ${remotes:zope}/z3c.relationfield.git pushurl=${remotes:zope_push}/z3c.relationfield.git branch=master
 zodbupdate                          = git ${remotes:zope}/zodbupdate.git pushurl=${remotes:zope_push}/zodbupdate.git branch=master
 zodbverify                          = git ${remotes:plone}/zodbverify.git pushurl=${remotes:plone_push}/zodbverify.git branch=master
-Zope                                = git ${remotes:zope}/Zope.git pushurl=${remotes:zope_push}/Zope.git branch=maurits-fileupload-charset-latin-1
+Zope                                = git ${remotes:zope}/Zope.git pushurl=${remotes:zope_push}/Zope.git branch=master
 
 
 [precompiler]

--- a/sources.cfg
+++ b/sources.cfg
@@ -29,7 +29,7 @@ zope_push = git@github.com:zopefoundation
 [sources]
 # non-eggs:
 docs                                = git ${remotes:plone}/documentation.git pushurl=${remotes:plone_push}/documentation.git egg=false branch=6-dev path=${buildout:docs-directory}
-mockup                              = git ${remotes:plone}/mockup.git pushurl=${remotes:plone_push}/mockup.git branch=maurits-no-charset-with-x-www-form-urlencoded-50x egg=false
+mockup                              = git ${remotes:plone}/mockup.git pushurl=${remotes:plone_push}/mockup.git branch=5.0.x egg=false
 plone.themepreview                  = git ${remotes:plone}/plone.themepreview.git pushurl=${remotes:plone_push}/plone.themepreview.git branch=master egg=false
 
 # eggs, keep sorted alphabetically please:
@@ -94,7 +94,7 @@ plone.dexterity                     = git ${remotes:plone}/plone.dexterity.git p
 plone.event                         = git ${remotes:plone}/plone.event.git pushurl=${remotes:plone_push}/plone.event.git branch=master
 plone.folder                        = git ${remotes:plone}/plone.folder.git pushurl=${remotes:plone_push}/plone.folder.git branch=master
 plone.formwidget.namedfile          = git ${remotes:plone}/plone.formwidget.namedfile.git pushurl=${remotes:plone_push}/plone.formwidget.namedfile.git branch=maurits-widget-tests-latin-1
-plone.formwidget.recurrence         = git ${remotes:plone}/plone.formwidget.recurrence.git pushurl=${remotes:plone_push}/plone.formwidget.recurrence.git branch=maurits-no-charset-with-x-www-form-urlencoded
+plone.formwidget.recurrence         = git ${remotes:plone}/plone.formwidget.recurrence.git pushurl=${remotes:plone_push}/plone.formwidget.recurrence.git branch=master
 plone.i18n                          = git ${remotes:plone}/plone.i18n.git pushurl=${remotes:plone_push}/plone.i18n.git branch=master
 plone.indexer                       = git ${remotes:plone}/plone.indexer.git pushurl=${remotes:plone_push}/plone.indexer.git branch=master
 plone.intelligenttext               = git ${remotes:plone}/plone.intelligenttext.git pushurl=${remotes:plone_push}/plone.intelligenttext.git branch=master
@@ -168,7 +168,7 @@ z3c.formwidget.query                = git ${remotes:zope}/z3c.formwidget.query.g
 z3c.relationfield                   = git ${remotes:zope}/z3c.relationfield.git pushurl=${remotes:zope_push}/z3c.relationfield.git branch=master
 zodbupdate                          = git ${remotes:zope}/zodbupdate.git pushurl=${remotes:zope_push}/zodbupdate.git branch=master
 zodbverify                          = git ${remotes:plone}/zodbverify.git pushurl=${remotes:plone_push}/zodbverify.git branch=master
-Zope                                = git ${remotes:zope}/Zope.git pushurl=${remotes:zope_push}/Zope.git branch=maurits-accept-but-ignore-charset-for-x-www-form-urlencoded
+Zope                                = git ${remotes:zope}/Zope.git pushurl=${remotes:zope_push}/Zope.git branch=charset_x-www-form-urlencod
 
 
 [precompiler]

--- a/sources.cfg
+++ b/sources.cfg
@@ -29,7 +29,7 @@ zope_push = git@github.com:zopefoundation
 [sources]
 # non-eggs:
 docs                                = git ${remotes:plone}/documentation.git pushurl=${remotes:plone_push}/documentation.git egg=false branch=6-dev path=${buildout:docs-directory}
-mockup                              = git ${remotes:plone}/mockup.git pushurl=${remotes:plone_push}/mockup.git branch=5.0.x egg=false
+mockup                              = git ${remotes:plone}/mockup.git pushurl=${remotes:plone_push}/mockup.git branch=maurits-no-charset-with-x-www-form-urlencoded-50x egg=false
 plone.themepreview                  = git ${remotes:plone}/plone.themepreview.git pushurl=${remotes:plone_push}/plone.themepreview.git branch=master egg=false
 
 # eggs, keep sorted alphabetically please:
@@ -94,7 +94,7 @@ plone.dexterity                     = git ${remotes:plone}/plone.dexterity.git p
 plone.event                         = git ${remotes:plone}/plone.event.git pushurl=${remotes:plone_push}/plone.event.git branch=master
 plone.folder                        = git ${remotes:plone}/plone.folder.git pushurl=${remotes:plone_push}/plone.folder.git branch=master
 plone.formwidget.namedfile          = git ${remotes:plone}/plone.formwidget.namedfile.git pushurl=${remotes:plone_push}/plone.formwidget.namedfile.git branch=maurits-widget-tests-latin-1
-plone.formwidget.recurrence         = git ${remotes:plone}/plone.formwidget.recurrence.git pushurl=${remotes:plone_push}/plone.formwidget.recurrence.git branch=master
+plone.formwidget.recurrence         = git ${remotes:plone}/plone.formwidget.recurrence.git pushurl=${remotes:plone_push}/plone.formwidget.recurrence.git branch=maurits-no-charset-with-x-www-form-urlencoded
 plone.i18n                          = git ${remotes:plone}/plone.i18n.git pushurl=${remotes:plone_push}/plone.i18n.git branch=master
 plone.indexer                       = git ${remotes:plone}/plone.indexer.git pushurl=${remotes:plone_push}/plone.indexer.git branch=master
 plone.intelligenttext               = git ${remotes:plone}/plone.intelligenttext.git pushurl=${remotes:plone_push}/plone.intelligenttext.git branch=master
@@ -168,7 +168,7 @@ z3c.formwidget.query                = git ${remotes:zope}/z3c.formwidget.query.g
 z3c.relationfield                   = git ${remotes:zope}/z3c.relationfield.git pushurl=${remotes:zope_push}/z3c.relationfield.git branch=master
 zodbupdate                          = git ${remotes:zope}/zodbupdate.git pushurl=${remotes:zope_push}/zodbupdate.git branch=master
 zodbverify                          = git ${remotes:plone}/zodbverify.git pushurl=${remotes:plone_push}/zodbverify.git branch=master
-Zope                                = git ${remotes:zope}/Zope.git pushurl=${remotes:zope_push}/Zope.git branch=master
+Zope                                = git ${remotes:zope}/Zope.git pushurl=${remotes:zope_push}/Zope.git branch=maurits-accept-but-ignore-charset-for-x-www-form-urlencoded
 
 
 [precompiler]

--- a/versions.cfg
+++ b/versions.cfg
@@ -5,9 +5,9 @@
 # Note: version pins in this file should only be removed in a new minor version of Plone.
 
 # Based on latest development Zope:
-# extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
+extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
 # Based on released Zope:
-extends = https://zopefoundation.github.io/Zope/releases/5.8/versions.cfg
+# extends = https://zopefoundation.github.io/Zope/releases/5.8/versions.cfg
 
 
 [versions]
@@ -168,11 +168,17 @@ z3c.objpath = 1.3
 z3c.relationfield = 0.9.0
 z3c.zcmlhook = 1.1
 zc.relation = 1.1.post2
+zdaemon = 4.4
+ZEO = 5.4.0
 ZODB3 = 3.11.0
+zodbupdate = 2.0
 zope.app.locales = 4.3
+zope.componentvocabulary = 2.3.0
 zope.copy = 4.3
 zope.intid = 4.4.0
 zope.keyreference = 5.0.0
+zope.ramcache = 2.4
+zope.sendmail = 5.3
 
 # CORE DEPENDENCIES: other
 # These packages are what you get when installing Plone and its tests,
@@ -180,18 +186,22 @@ zope.keyreference = 5.0.0
 async-generator = 1.10
 attrs = 22.2.0
 cssselect = 1.2.0
+cryptography = 39.0.1
 decorator = 5.1.1
 exceptiongroup = 1.1.0
 feedparser = 6.0.10
 furl = 2.1.3
+future = 0.18.3
 gunicorn = 20.1.0
 h11 = 0.14.0
 importlib-metadata = 5.2.0
 importlib-resources = 5.10.2
 jsonschema = 4.17.3
+jeepney = 0.8.0
 lxml = 4.9.2
 manuel = 1.12.4
 Markdown = 3.4.1
+mock = 5.0.1
 orderedmultidict = 1.0.1
 outcome = 1.2.0
 piexif = 1.1.3
@@ -212,6 +222,7 @@ robotframework-selenium2library = 3.0.0
 robotframework-selenium2screenshots = 0.8.1
 robotframework-seleniumlibrary = 6.0.0
 robotframework-seleniumtestability = 2.0.0
+SecretStorage = 3.3.3
 selenium = 4.7.2
 sgmllib3k = 1.0.0
 simplejson = 3.18.3


### PR DESCRIPTION
There are several major updates there, which should be fine: they drop Python 2 support.

I do see that several pins have been dropped, so we need to add more ourselves. This is the output when allowing unpinned versions:

```
[versions]
mock = 5.0.1
zope.sendmail = 5.3

# Required by:
# plone.recipe.zope2instance==6.12.0
ZEO = 5.4.0

# Required by:
# repoze.xmliter==0.6.1
future = 0.18.3

# Required by:
# ZEO==5.4.0
zdaemon = 4.4

# Required by:
# five.customerize==2.1.0
# plone.contentrules==2.1.2
zope.componentvocabulary = 2.3.0

# Required by:
# plone.app.caching==3.0.4.dev0
# plone.memoize==3.0.0
zope.ramcache = 2.4
```

I added them.