### PR TITLE
Undo checkout of plone.app.linkintegrity.

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -31,7 +31,8 @@ auto-checkout =
     plone.app.portlets
     plone.base
     plone.app.layout
-    plone.app.linkintegrity
+# This may have broken Jenkins, but not sure yet.
+#    plone.app.linkintegrity
     Products.CMFPlacefulWorkflow
     plone.subrequest
     plone.schemaeditor


### PR DESCRIPTION
The Plone 6.0 jobs are failing since yesterday.
For Py 3.11, this is the first failing job, with 334 test failures: https://jenkins.plone.org/job/plone-6.0-python-3.11/470/
I tried a few of the failing tests locally, but they passed.

This is after the merge of a PR from me:
https://github.com/plone/plone.app.linkintegrity/pull/87
The PR tests passed, so it could be coincidence.  Let's try.