### PR TITLE
Checkout plone.app.linkintegrity again.

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -31,8 +31,7 @@ auto-checkout =
     plone.app.portlets
     plone.base
     plone.app.layout
-# This may have broken Jenkins, but not sure yet.
-#    plone.app.linkintegrity
+    plone.app.linkintegrity
     Products.CMFPlacefulWorkflow
     plone.subrequest
     plone.schemaeditor


### PR DESCRIPTION
With the checkout, Jenkins was broken on all Plone 6.0 jobs, with 334 failures. Reverting that in https://github.com/plone/buildout.coredev/pull/846 helped: Jenkins is green again. So if I check it out again, the PR jobs should fail.  But they were green on the initial PR in linkintegrity. So maybe there is a subtle difference in how the core jobs and the PR jobs are run, like using multiple threads.