### PR TITLE
Use Zope 5.8.3 on Plone 6.0

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -7,7 +7,7 @@
 # Based on latest development Zope:
 # extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
 # Based on released Zope:
-extends = https://zopefoundation.github.io/Zope/releases/5.8.2/versions.cfg
+extends = https://zopefoundation.github.io/Zope/releases/5.8.3/versions.cfg
 
 
 [versions]


### PR DESCRIPTION
Released yesterday:
https://community.plone.org/t/zope-5-8-3-released/17565
