### PR TITLE
Use pip 23.2 and setuptools 68.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pip==23.1.2
-setuptools==67.8.0
+pip==23.2
+setuptools==68.0.0
 wheel==0.40.0
 zc.buildout==3.0.1
 

--- a/versions.cfg
+++ b/versions.cfg
@@ -13,8 +13,8 @@ extends = https://zopefoundation.github.io/Zope/releases/5.8.3/versions.cfg
 [versions]
 # Basics
 # !! keep in sync with requirements.txt !!
-pip = 23.1.2
-setuptools = 67.8.0
+pip = 23.2
+setuptools = 68.0.0
 wheel = 0.40.0
 zc.buildout = 3.0.1
 


### PR DESCRIPTION
See [pip changelog](https://pip.pypa.io/en/stable/news/).  Of interest:

* Fix slowness when using importlib.metadata (the default way for pip to read metadata in Python 3.11+) and there is a large overlap between already installed and to-be-installed packages.  That was my fix.
* freeze no longer excludes the setuptools, distribute, and wheel from the output when running on Python 3.12 or later, where they are not included in a virtual environment by default. Use --exclude if you wish to exclude any of these packages.

And see [setuptools history](https://setuptools.pypa.io/en/latest/history.html).  This removes several items that were long deprecated.  Nothing that immediately stands out for me.