### PR TITLE
Add unofficial newer-versions.cfg to 5.2.

### DIFF
--- a/newer-versions.cfg
+++ b/newer-versions.cfg
@@ -1,0 +1,49 @@
+# This file contains unofficial newer version pins for a few packages.
+# These are known to work on Plone 5.2, but there are reasons to not include
+# them officially.  The changes in there may be slightly more "adventurous"
+# than is deemed wise at this late stage in the Plone 5.2 release cycle:
+# currently (November 2023) Plone 5.2 is even out of maintenance support.
+# Some do not work on Python 2, and we do not want to have two different
+# version pins for core packages, to avoid confusion.
+#
+# * This file is NOT automatically being tested.
+# * This file is NOT regularly updated.
+# * We recommend to NOT use this file directly, but to take over the versions
+#   you want in your own versions files.
+#
+# In short: use this at your own risk, and if you know what you are doing.
+
+[versions]
+# plone.dexterity has a fix for a possible memory leak.
+# See https://github.com/plone/Products.CMFPlone/issues/3829
+# Main change is here:
+# https://github.com/plone/plone.dexterity/pull/189
+plone.dexterity = 2.11.0
+
+# The newer plone.dexterity version leads to test failures on Python 3,
+# which may or may not happen in production use as well.  plone.supermodel
+# backports a fix made for the dexterity site root in Plone 6, which
+# helps for this new situation as well.
+# Main change is here:
+# https://github.com/plone/plone.supermodel/pull/55
+plone.supermodel = 1.7.0
+
+[versions:python3]
+# These are versions that are incompatible with Python 2.
+# They are used in Plone 6.0, but are being tested on Plone 5.2 as well.
+
+# We try to keep latest plone.restapi compatible with a wide range of Plone
+# versions, including Plone 5.2.
+plone.restapi = 9.1.2
+
+# plone.volto configures Plone to work with Volto, the new default frontend for
+# Plone 6.
+plone.volto = 4.1.0
+
+# Newer plone.namedfile and plone.scale work together to pre-register image
+# scales without generating them yet.  This means that creating a tag no longer
+# generates the actual scale: generating is only done when the scale is
+# actually requested by a browser.
+# See `CHANGES.rst` in both packages to look for other large changes.
+plone.namedfile = 6.2.3
+plone.scale = 4.1.0


### PR DESCRIPTION
This file contains unofficial newer version pins for a few packages. These are known to work on Plone 5.2, but there are reasons to not include them officially.  The changes in there may be slightly more adventurous than is deemed wise at this late stage in the Plone 5.2 release cycle: currently (November 2023) Plone 5.2 is even out of maintenance support. Some do not work on Python 2, and we do not want to have two different version pins for core packages, to avoid confusion.