### PR TITLE
New versions for 6.0, 2023-12-07

### DIFF
--- a/versions-extra.cfg
+++ b/versions-extra.cfg
@@ -3,8 +3,8 @@
 # that pull in ever more dependencies.
 # Note: version pins in this file can be removed at any time.
 [versions]
-argcomplete = 3.1.4
-argh = 0.29.4
+argcomplete = 3.1.6
+argh = 0.30.4
 bleach = 6.1.0
 build = 1.0.3
 cachecontrol = 0.13.1
@@ -26,7 +26,7 @@ httplib2 = 0.22.0
 i18ndude = 6.1.0
 incremental = 22.10.0
 jaraco.classes = 3.3.0
-keyring = 24.2.0
+keyring = 24.3.0
 lockfile = 0.12.2
 markdown-it-py = 3.0.0
 mdurl = 0.1.2
@@ -37,7 +37,7 @@ nh3 = 0.2.14
 oauthlib = 3.2.2
 pdbpp = 0.10.3
 pep440 = 0.1.2
-pep517 = 0.13.0
+pep517 = 0.13.1
 pkginfo = 1.9.6
 plone.recipe.zeoserver = 3.0.1
 plone.releaser = 2.2.0
@@ -53,9 +53,9 @@ pyroma = 4.2
 readme-renderer = 42.0
 requests-toolbelt = 1.0.0
 rfc3986 = 2.0.0
-rich = 13.6.0
+rich = 13.7.0
 smmap = 5.0.1
-stdlib-list = 0.9.0
+stdlib-list = 0.10.0
 tomli = 2.0.1
 towncrier = 23.11.0
 trove-classifiers = 2023.11.29
@@ -70,3 +70,7 @@ zestreleaser.towncrier = 1.3.0
 zodbverify = 1.2.0
 zope.mkzeoinstance = 5.1.1
 ZopeUndo = 6.0
+
+[versionannotations]
+grpcio-tools =
+    Requirement of robotframework-browser: grpcio-tools==1.59.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -159,7 +159,7 @@ Products.PythonScripts = 5.0
 Products.Sessions = 5.0
 Products.SiteErrorLog = 6.0
 Products.StandardCacheManagers = 5.0
-Products.ZopeVersionControl = 4.0
+Products.ZopeVersionControl = 4.1
 repoze.xmliter = 0.6.1
 z3c.caching = 3.0
 z3c.form = 4.3
@@ -169,6 +169,8 @@ z3c.relationfield = 1.0
 z3c.zcmlhook = 2.0
 zc.relation = 2.0
 zdaemon = 5.0
+# On Python 3.12 we use ZEO 6.0.0.
+# Should be fine for all versions, but let's wait one Plone release for that.
 ZEO = 5.4.1
 ZODB3 = 3.11.0
 zodbupdate = 2.0
@@ -186,20 +188,19 @@ zope.sendmail = 6.0
 async-generator = 1.10
 attrs = 23.1.0
 backports.cached-property = 1.0.2
-cryptography = 41.0.6
+cryptography = 41.0.7
 click = 8.1.7
 cssselect = 1.2.0
 decorator = 5.1.1
-exceptiongroup = 1.1.3
+exceptiongroup = 1.2.0
 feedparser = 6.0.10
 furl = 2.1.3
 future = 0.18.3
 gunicorn = 21.2.0
 h11 = 0.14.0
-importlib-metadata = 6.8.0
 importlib-resources = 5.13.0
-jsonschema = 4.19.2
-jsonschema-specifications = 2023.7.1
+jsonschema = 4.20.0
+jsonschema-specifications = 2023.11.2
 jeepney = 0.8.0
 lxml = 4.9.3
 manuel = 1.12.4
@@ -219,8 +220,8 @@ PySocks = 1.7.1
 python-dateutil = 2.8.2
 python-dotenv = 1.0.0
 PyYAML = 6.0.1
-referencing = 0.30.2
-responses = 0.24.0
+referencing = 0.31.1
+responses = 0.24.1
 robotframework = 6.0.2
 # robotframework >= 6.1 is only supported with robotframwork-lsp >= 1.11.0,
 # but https://github.com/robocorp/robotframework-lsp/issues/947
@@ -231,9 +232,9 @@ robotframework-debuglibrary = 2.3.0
 robotframework-pythonlibcore = 4.2.0
 robotframework-selenium2library = 3.0.0
 robotframework-selenium2screenshots = 0.8.1
-robotframework-seleniumlibrary = 6.1.0
+robotframework-seleniumlibrary = 6.1.3
 robotframework-seleniumtestability = 2.1.0
-rpds-py = 0.12.0
+rpds-py = 0.13.2
 SecretStorage = 3.3.3
 selenium = 4.9.1
 sgmllib3k = 1.0.0
@@ -249,14 +250,17 @@ typing-extensions = 4.8.0
 Unidecode = 1.3.7
 urllib3-secure-extra = 0.1.0
 watchdog = 3.0.0
-wcwidth = 0.2.9
+wcwidth = 0.2.12
 webresource = 1.2
-wrapt = 1.15.0
+wrapt = 1.16.0
 wsproto = 1.2.0
 
 [versions:python38]
 backports.zoneinfo = 0.2.1
 pkgutil-resolve-name = 1.3.10
+
+[versions:python312]
+ZEO = 6.0.0
 
 [versionannotations]
 # keep this alphabetical please


### PR DESCRIPTION
Let me draw your attention to one change: I have updated ZEO to 6.0.0.  This adds support for Python 3.12.  I have a small doubt about introducing the [other changes](https://pypi.org/project/ZEO/6.0.0/) in a Plone bugfix release. Especially "Switch to using async/await directly instead of @coroutine/yield" sounds like it could potentially have side effects that only become clear when it gets used.  So let's give this a chance on Python 3.12.  We can see later if we dare to introduce this for the other Python versions as well.