### PR TITLE
Create mxdev sources and checkouts

### DIFF
--- a/checkouts.ini
+++ b/checkouts.ini
@@ -1,0 +1,33 @@
+# File created by release/create-mxcheckouts.py
+# Parsed from buildout.cfg
+
+[settings]
+default-use = false
+
+
+[docs]
+use = true
+
+[mockup]
+use = true
+
+[Plone]
+use = true
+
+[plone.app.locales]
+use = true
+
+[plone.app.upgrade]
+use = true
+
+[plone.restapi]
+use = true
+
+[plone.volto]
+use = true
+
+[plonetheme.barceloneta]
+use = true
+
+[Products.CMFPlone]
+use = true

--- a/release/create-mxcheckouts.py
+++ b/release/create-mxcheckouts.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""Parse checkouts from a buildout configuration and write to a mxdev
+compatible ini file.
+
+This script is called by 'tox -c release/tox.ini -e create-mxcheckouts.py'
+
+Manual usage: bin/python create-mxcheckouts.py
+"""
+
+# From: create-constraints.py
+
+import os
+import sys
+
+from zc.buildout import buildout
+
+if not len(sys.argv) == 3:
+    print("ERROR. Usage: create-mxcheckouts.py buildout.cfg checkouts.ini")
+    sys.exit(1)
+config_file = sys.argv[1]
+config_file = os.path.realpath(config_file)
+checkouts_file = sys.argv[2]
+checkouts_file = os.path.realpath(os.path.join(os.getcwd(), checkouts_file))
+config = buildout.Buildout(config_file, [])
+
+checkouts = config.get("buildout", {}).get("auto-checkout", "").split("\n")
+
+with open(checkouts_file, "w") as cfile:
+    cfile.write(f"# File created by {os.path.relpath(__file__)}\n")
+    cfile.write(f"# Parsed from {os.path.relpath(config_file)}\n")
+
+    # Set default to not checkout any sources.
+    cfile.write("\n[settings]\n")
+    cfile.write("default-use = false\n")
+
+    cfile.write("\n")
+    for name in sorted(checkouts, key=lambda x: x.lower()):
+        cfile.write(f"\n[{name}]\n")
+        cfile.write("use = true\n")
+
+print(f"Wrote all checkouts to {os.path.relpath(checkouts_file)}")

--- a/release/create-mxsources.py
+++ b/release/create-mxsources.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""Parse sources from a buildout configuration and write to a mxdev compatible
+ini file.
+
+This script is called by 'tox -c release/tox.ini -e create-mxsources.py'
+
+Manual usage: bin/python create-mxsources.py
+"""
+
+# From: create-constraints.py
+
+import os
+import sys
+
+from zc.buildout import buildout
+
+if not len(sys.argv) == 3:
+    print("ERROR. Usage: create-mxsources.py buildout.cfg sources.ini")
+    sys.exit(1)
+config_file = sys.argv[1]
+config_file = os.path.realpath(config_file)
+sources_file = sys.argv[2]
+sources_file = os.path.realpath(os.path.join(os.getcwd(), sources_file))
+config = buildout.Buildout(config_file, [])
+
+sources = config.get("sources", {})
+remotes = config.get("remotes", {})
+
+# Special case:
+# Remove github and github_push from remotes in favor of zope and zope_push.
+if "github" in remotes:
+    del remotes["github"]
+if "github_push" in remotes:
+    del remotes["github_push"]
+
+with open(sources_file, "w") as cfile:
+    cfile.write(f"# File created by {os.path.relpath(__file__)}\n")
+    cfile.write(f"# Parsed from {os.path.relpath(config_file)}\n")
+
+    # Write the remotes.
+    cfile.write("\n[settings]\n")
+    cfile.write("\n# Remote definitions for source checkouts.\n")
+
+    for key, val in sorted(remotes.items(), key=lambda x: x[0].lower()):
+        cfile.write(f"{key} = {val}\n")
+
+    # Write the sources
+    cfile.write("\n")
+    for key, val in sorted(sources.items(), key=lambda x: x[0].lower()):
+        vals = val.split(" ")
+        cfg = {}
+        cfg[key] = {}
+        for it in vals:
+            it_ = it.split("=")
+            if len(it_) == 1:
+                if it_[0] == "git":
+                    continue
+                url = it_[0]
+                # Replace the urls with remote definitions, if possible.
+                for key_, val_ in remotes.items():
+                    if url.startswith(val_):
+                        url = url.replace(val_, f"${{settings:{key_}}}")
+                        break
+                cfg[key]["url"] = url
+                continue
+
+            if it_[0] == "pushurl":
+                # Replace the urls with remote definitions, if possible.
+                for key_, val_ in remotes.items():
+                    if it_[1].startswith(val_):
+                        it_[1] = it_[1].replace(val_, f"${{settings:{key_}}}")
+                        break
+                cfg[key]["pushurl"] = it_[0]
+
+            if it_[0] == "egg":
+                if it_[1].lower() == "true":
+                    continue
+                # We want to skip if egg is set to false.
+                cfg[key]["install-mode"] = "skip"
+                continue
+            if it_[0] == "path":
+                cfg[key]["target"] = os.path.relpath(it_[1])
+                continue
+            cfg[key][it_[0]] = it_[1]
+
+        # Explicitly set the branch.
+        # Default branch in buildout is "master", for git it is "main".
+        if not cfg[key].get("branch"):
+            cfg[key]["branch"] = "master"
+
+        for name, cfg in cfg.items():
+            cfile.write(f"\n[{name}]\n")
+            for key_, val_ in sorted(cfg.items()):
+                cfile.write(f"{key_} = {val_}\n")
+
+print(f"Wrote all sources to {os.path.relpath(sources_file)}")

--- a/sources.ini
+++ b/sources.ini
@@ -1,0 +1,982 @@
+# File created by release/create-mxsources.py
+# Parsed from buildout.cfg
+
+[settings]
+
+# Remote definitions for source checkouts.
+collective = https://github.com/collective
+collective_push = git@github.com:collective
+plone = https://github.com/plone
+plone_push = git@github.com:plone
+zope = https://github.com/zopefoundation
+zope_push = git@github.com:zopefoundation
+
+
+[AccessControl]
+branch = master
+pushurl = ${settings:zope_push}/AccessControl
+url = ${settings:zope}/AccessControl
+
+[Acquisition]
+branch = master
+pushurl = ${settings:zope_push}/Acquisition
+url = ${settings:zope}/Acquisition
+
+[AuthEncoding]
+branch = master
+pushurl = ${settings:zope_push}/AuthEncoding
+url = ${settings:zope}/AuthEncoding
+
+[borg.localrole]
+branch = master
+pushurl = ${settings:plone_push}/borg.localrole.git
+url = ${settings:plone}/borg.localrole.git
+
+[BTrees]
+branch = master
+pushurl = ${settings:zope_push}/BTrees
+url = ${settings:zope}/BTrees
+
+[collective.monkeypatcher]
+branch = master
+pushurl = ${settings:plone_push}/collective.monkeypatcher.git
+url = ${settings:plone}/collective.monkeypatcher.git
+
+[collective.recipe.omelette]
+branch = master
+pushurl = ${settings:collective_push}/collective.recipe.omelette.git
+url = ${settings:collective}/collective.recipe.omelette.git
+
+[collective.xmltestreport]
+branch = master
+pushurl = ${settings:collective_push}/collective.xmltestreport.git
+url = ${settings:collective}/collective.xmltestreport.git
+
+[DateTime]
+branch = master
+pushurl = ${settings:zope_push}/DateTime
+url = ${settings:zope}/DateTime
+
+[diazo]
+branch = master
+pushurl = ${settings:plone_push}/diazo.git
+url = ${settings:plone}/diazo.git
+
+[docs]
+branch = 6.0
+install-mode = skip
+pushurl = ${settings:plone_push}/documentation.git
+target = documentation
+url = ${settings:plone}/documentation.git
+
+[DocumentTemplate]
+branch = master
+pushurl = ${settings:zope_push}/DocumentTemplate
+url = ${settings:zope}/DocumentTemplate
+
+[ExtensionClass]
+branch = master
+pushurl = ${settings:zope_push}/ExtensionClass
+url = ${settings:zope}/ExtensionClass
+
+[five.customerize]
+branch = master
+pushurl = ${settings:zope_push}/five.customerize.git
+url = ${settings:zope}/five.customerize.git
+
+[five.intid]
+branch = master
+pushurl = ${settings:plone_push}/five.intid.git
+url = ${settings:plone}/five.intid.git
+
+[five.localsitemanager]
+branch = master
+pushurl = ${settings:zope_push}/five.localsitemanager
+url = ${settings:zope}/five.localsitemanager
+
+[i18ndude]
+branch = master
+pushurl = ${settings:collective_push}/i18ndude.git
+url = ${settings:collective}/i18ndude.git
+
+[icalendar]
+branch = master
+pushurl = ${settings:collective_push}/icalendar.git
+url = ${settings:collective}/icalendar.git
+
+[Missing]
+branch = master
+pushurl = ${settings:zope_push}/Missing
+url = ${settings:zope}/Missing
+
+[mockup]
+branch = master
+install-mode = skip
+pushurl = ${settings:plone_push}/mockup.git
+url = ${settings:plone}/mockup.git
+
+[MultiMapping]
+branch = master
+pushurl = ${settings:zope_push}/MultiMapping
+url = ${settings:zope}/MultiMapping
+
+[Persistence]
+branch = master
+pushurl = ${settings:zope_push}/Persistence
+url = ${settings:zope}/Persistence
+
+[Plone]
+branch = master
+pushurl = ${settings:plone_push}/Plone.git
+url = ${settings:plone}/Plone.git
+
+[plone.alterego]
+branch = master
+pushurl = ${settings:plone_push}/plone.alterego.git
+url = ${settings:plone}/plone.alterego.git
+
+[plone.api]
+branch = master
+pushurl = ${settings:plone_push}/plone.api.git
+url = ${settings:plone}/plone.api.git
+
+[plone.app.caching]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.caching.git
+url = ${settings:plone}/plone.app.caching.git
+
+[plone.app.content]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.content.git
+url = ${settings:plone}/plone.app.content.git
+
+[plone.app.contentlisting]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.contentlisting.git
+url = ${settings:plone}/plone.app.contentlisting.git
+
+[plone.app.contentmenu]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.contentmenu.git
+url = ${settings:plone}/plone.app.contentmenu.git
+
+[plone.app.contentrules]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.contentrules.git
+url = ${settings:plone}/plone.app.contentrules.git
+
+[plone.app.contenttypes]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.contenttypes.git
+url = ${settings:plone}/plone.app.contenttypes.git
+
+[plone.app.customerize]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.customerize.git
+url = ${settings:plone}/plone.app.customerize.git
+
+[plone.app.dexterity]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.dexterity.git
+url = ${settings:plone}/plone.app.dexterity.git
+
+[plone.app.discussion]
+branch = main
+pushurl = ${settings:plone_push}/plone.app.discussion.git
+url = ${settings:plone}/plone.app.discussion.git
+
+[plone.app.event]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.event.git
+url = ${settings:plone}/plone.app.event.git
+
+[plone.app.i18n]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.i18n.git
+url = ${settings:plone}/plone.app.i18n.git
+
+[plone.app.intid]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.intid.git
+url = ${settings:plone}/plone.app.intid.git
+
+[plone.app.iterate]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.iterate.git
+url = ${settings:plone}/plone.app.iterate.git
+
+[plone.app.layout]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.layout.git
+url = ${settings:plone}/plone.app.layout.git
+
+[plone.app.linkintegrity]
+branch = main
+pushurl = ${settings:plone_push}/plone.app.linkintegrity.git
+url = ${settings:plone}/plone.app.linkintegrity.git
+
+[plone.app.locales]
+branch = master
+pushurl = ${settings:collective_push}/plone.app.locales.git
+url = ${settings:collective}/plone.app.locales.git
+
+[plone.app.lockingbehavior]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.lockingbehavior.git
+url = ${settings:plone}/plone.app.lockingbehavior.git
+
+[plone.app.multilingual]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.multilingual.git
+url = ${settings:plone}/plone.app.multilingual.git
+
+[plone.app.portlets]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.portlets.git
+url = ${settings:plone}/plone.app.portlets.git
+
+[plone.app.querystring]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.querystring.git
+url = ${settings:plone}/plone.app.querystring.git
+
+[plone.app.redirector]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.redirector.git
+url = ${settings:plone}/plone.app.redirector.git
+
+[plone.app.registry]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.registry.git
+url = ${settings:plone}/plone.app.registry.git
+
+[plone.app.relationfield]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.relationfield.git
+url = ${settings:plone}/plone.app.relationfield.git
+
+[plone.app.robotframework]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.robotframework.git
+url = ${settings:plone}/plone.app.robotframework.git
+
+[plone.app.testing]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.testing.git
+url = ${settings:plone}/plone.app.testing.git
+
+[plone.app.textfield]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.textfield.git
+url = ${settings:plone}/plone.app.textfield.git
+
+[plone.app.theming]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.theming.git
+url = ${settings:plone}/plone.app.theming.git
+
+[plone.app.upgrade]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.upgrade.git
+url = ${settings:plone}/plone.app.upgrade.git
+
+[plone.app.users]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.users.git
+url = ${settings:plone}/plone.app.users.git
+
+[plone.app.uuid]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.uuid.git
+url = ${settings:plone}/plone.app.uuid.git
+
+[plone.app.versioningbehavior]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.versioningbehavior.git
+url = ${settings:plone}/plone.app.versioningbehavior.git
+
+[plone.app.viewletmanager]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.viewletmanager.git
+url = ${settings:plone}/plone.app.viewletmanager.git
+
+[plone.app.vocabularies]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.vocabularies.git
+url = ${settings:plone}/plone.app.vocabularies.git
+
+[plone.app.widgets]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.widgets.git
+url = ${settings:plone}/plone.app.widgets.git
+
+[plone.app.workflow]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.workflow.git
+url = ${settings:plone}/plone.app.workflow.git
+
+[plone.app.z3cform]
+branch = master
+pushurl = ${settings:plone_push}/plone.app.z3cform.git
+url = ${settings:plone}/plone.app.z3cform.git
+
+[plone.autoform]
+branch = master
+pushurl = ${settings:plone_push}/plone.autoform.git
+url = ${settings:plone}/plone.autoform.git
+
+[plone.autoinclude]
+branch = main
+pushurl = ${settings:plone_push}/plone.autoinclude.git
+url = ${settings:plone}/plone.autoinclude.git
+
+[plone.base]
+branch = main
+pushurl = ${settings:plone_push}/plone.base.git
+url = ${settings:plone}/plone.base.git
+
+[plone.batching]
+branch = master
+pushurl = ${settings:plone_push}/plone.batching.git
+url = ${settings:plone}/plone.batching.git
+
+[plone.behavior]
+branch = master
+pushurl = ${settings:plone_push}/plone.behavior.git
+url = ${settings:plone}/plone.behavior.git
+
+[plone.browserlayer]
+branch = master
+pushurl = ${settings:plone_push}/plone.browserlayer.git
+url = ${settings:plone}/plone.browserlayer.git
+
+[plone.cachepurging]
+branch = master
+pushurl = ${settings:plone_push}/plone.cachepurging.git
+url = ${settings:plone}/plone.cachepurging.git
+
+[plone.caching]
+branch = master
+pushurl = ${settings:plone_push}/plone.caching.git
+url = ${settings:plone}/plone.caching.git
+
+[plone.contentrules]
+branch = master
+pushurl = ${settings:plone_push}/plone.contentrules.git
+url = ${settings:plone}/plone.contentrules.git
+
+[plone.dexterity]
+branch = master
+pushurl = ${settings:plone_push}/plone.dexterity.git
+url = ${settings:plone}/plone.dexterity.git
+
+[plone.event]
+branch = master
+pushurl = ${settings:plone_push}/plone.event.git
+url = ${settings:plone}/plone.event.git
+
+[plone.folder]
+branch = master
+pushurl = ${settings:plone_push}/plone.folder.git
+url = ${settings:plone}/plone.folder.git
+
+[plone.formwidget.namedfile]
+branch = master
+pushurl = ${settings:plone_push}/plone.formwidget.namedfile.git
+url = ${settings:plone}/plone.formwidget.namedfile.git
+
+[plone.formwidget.recurrence]
+branch = master
+pushurl = ${settings:plone_push}/plone.formwidget.recurrence.git
+url = ${settings:plone}/plone.formwidget.recurrence.git
+
+[plone.i18n]
+branch = master
+pushurl = ${settings:plone_push}/plone.i18n.git
+url = ${settings:plone}/plone.i18n.git
+
+[plone.indexer]
+branch = master
+pushurl = ${settings:plone_push}/plone.indexer.git
+url = ${settings:plone}/plone.indexer.git
+
+[plone.intelligenttext]
+branch = master
+pushurl = ${settings:plone_push}/plone.intelligenttext.git
+url = ${settings:plone}/plone.intelligenttext.git
+
+[plone.keyring]
+branch = master
+pushurl = ${settings:plone_push}/plone.keyring.git
+url = ${settings:plone}/plone.keyring.git
+
+[plone.locking]
+branch = master
+pushurl = ${settings:plone_push}/plone.locking.git
+url = ${settings:plone}/plone.locking.git
+
+[plone.memoize]
+branch = master
+pushurl = ${settings:plone_push}/plone.memoize.git
+url = ${settings:plone}/plone.memoize.git
+
+[plone.namedfile]
+branch = master
+pushurl = ${settings:plone_push}/plone.namedfile.git
+url = ${settings:plone}/plone.namedfile.git
+
+[plone.outputfilters]
+branch = master
+pushurl = ${settings:plone_push}/plone.outputfilters.git
+url = ${settings:plone}/plone.outputfilters.git
+
+[plone.portlet.collection]
+branch = master
+pushurl = ${settings:plone_push}/plone.portlet.collection.git
+url = ${settings:plone}/plone.portlet.collection.git
+
+[plone.portlet.static]
+branch = master
+pushurl = ${settings:plone_push}/plone.portlet.static.git
+url = ${settings:plone}/plone.portlet.static.git
+
+[plone.portlets]
+branch = master
+pushurl = ${settings:plone_push}/plone.portlets.git
+url = ${settings:plone}/plone.portlets.git
+
+[plone.protect]
+branch = master
+pushurl = ${settings:plone_push}/plone.protect.git
+url = ${settings:plone}/plone.protect.git
+
+[plone.recipe.alltests]
+branch = master
+pushurl = ${settings:plone_push}/plone.recipe.alltests.git
+url = ${settings:plone}/plone.recipe.alltests.git
+
+[plone.recipe.precompiler]
+branch = master
+pushurl = ${settings:plone_push}/plone.recipe.precompiler.git
+url = ${settings:plone}/plone.recipe.precompiler.git
+
+[plone.recipe.zeoserver]
+branch = master
+pushurl = ${settings:plone_push}/plone.recipe.zeoserver.git
+url = ${settings:plone}/plone.recipe.zeoserver.git
+
+[plone.recipe.zope2instance]
+branch = master
+pushurl = ${settings:plone_push}/plone.recipe.zope2instance.git
+url = ${settings:plone}/plone.recipe.zope2instance.git
+
+[plone.registry]
+branch = master
+pushurl = ${settings:plone_push}/plone.registry.git
+url = ${settings:plone}/plone.registry.git
+
+[plone.releaser]
+branch = master
+pushurl = ${settings:plone_push}/plone.releaser.git
+url = ${settings:plone}/plone.releaser.git
+
+[plone.reload]
+branch = master
+pushurl = ${settings:plone_push}/plone.reload.git
+url = ${settings:plone}/plone.reload.git
+
+[plone.resource]
+branch = master
+pushurl = ${settings:plone_push}/plone.resource.git
+url = ${settings:plone}/plone.resource.git
+
+[plone.resourceeditor]
+branch = master
+pushurl = ${settings:plone_push}/plone.resourceeditor.git
+url = ${settings:plone}/plone.resourceeditor.git
+
+[plone.rest]
+branch = main
+pushurl = ${settings:plone_push}/plone.rest.git
+url = ${settings:plone}/plone.rest.git
+
+[plone.restapi]
+branch = main
+pushurl = ${settings:plone_push}/plone.restapi.git
+url = ${settings:plone}/plone.restapi.git
+
+[plone.rfc822]
+branch = master
+pushurl = ${settings:plone_push}/plone.rfc822.git
+url = ${settings:plone}/plone.rfc822.git
+
+[plone.scale]
+branch = master
+pushurl = ${settings:plone_push}/plone.scale.git
+url = ${settings:plone}/plone.scale.git
+
+[plone.schema]
+branch = master
+pushurl = ${settings:plone_push}/plone.schema.git
+url = ${settings:plone}/plone.schema.git
+
+[plone.schemaeditor]
+branch = master
+pushurl = ${settings:plone_push}/plone.schemaeditor.git
+url = ${settings:plone}/plone.schemaeditor.git
+
+[plone.session]
+branch = master
+pushurl = ${settings:plone_push}/plone.session.git
+url = ${settings:plone}/plone.session.git
+
+[plone.staticresources]
+branch = master
+pushurl = ${settings:plone_push}/plone.staticresources.git
+url = ${settings:plone}/plone.staticresources.git
+
+[plone.stringinterp]
+branch = master
+pushurl = ${settings:plone_push}/plone.stringinterp.git
+url = ${settings:plone}/plone.stringinterp.git
+
+[plone.subrequest]
+branch = master
+pushurl = ${settings:plone_push}/plone.subrequest.git
+url = ${settings:plone}/plone.subrequest.git
+
+[plone.supermodel]
+branch = master
+pushurl = ${settings:plone_push}/plone.supermodel.git
+url = ${settings:plone}/plone.supermodel.git
+
+[plone.testing]
+branch = master
+pushurl = ${settings:plone_push}/plone.testing.git
+url = ${settings:plone}/plone.testing.git
+
+[plone.theme]
+branch = master
+pushurl = ${settings:plone_push}/plone.theme.git
+url = ${settings:plone}/plone.theme.git
+
+[plone.themepreview]
+branch = master
+install-mode = skip
+pushurl = ${settings:plone_push}/plone.themepreview.git
+url = ${settings:plone}/plone.themepreview.git
+
+[plone.tiles]
+branch = master
+pushurl = ${settings:plone_push}/plone.tiles.git
+url = ${settings:plone}/plone.tiles.git
+
+[plone.transformchain]
+branch = master
+pushurl = ${settings:plone_push}/plone.transformchain.git
+url = ${settings:plone}/plone.transformchain.git
+
+[plone.uuid]
+branch = master
+pushurl = ${settings:plone_push}/plone.uuid.git
+url = ${settings:plone}/plone.uuid.git
+
+[plone.versioncheck]
+branch = master
+pushurl = ${settings:plone_push}/plone.versioncheck.git
+url = ${settings:plone}/plone.versioncheck.git
+
+[plone.volto]
+branch = main
+pushurl = ${settings:plone_push}/plone.volto.git
+url = ${settings:plone}/plone.volto.git
+
+[plone.z3cform]
+branch = master
+pushurl = ${settings:plone_push}/plone.z3cform.git
+url = ${settings:plone}/plone.z3cform.git
+
+[plonetheme.barceloneta]
+branch = master
+pushurl = ${settings:plone_push}/plonetheme.barceloneta.git
+url = ${settings:plone}/plonetheme.barceloneta.git
+
+[Products.BTreeFolder2]
+branch = master
+pushurl = ${settings:zope_push}/Products.BTreeFolder2
+url = ${settings:zope}/Products.BTreeFolder2
+
+[Products.CMFCore]
+branch = master
+pushurl = ${settings:zope_push}/Products.CMFCore.git
+url = ${settings:zope}/Products.CMFCore.git
+
+[Products.CMFDiffTool]
+branch = master
+pushurl = ${settings:plone_push}/Products.CMFDiffTool.git
+url = ${settings:plone}/Products.CMFDiffTool.git
+
+[Products.CMFDynamicViewFTI]
+branch = master
+pushurl = ${settings:plone_push}/Products.CMFDynamicViewFTI.git
+url = ${settings:plone}/Products.CMFDynamicViewFTI.git
+
+[Products.CMFEditions]
+branch = master
+pushurl = ${settings:plone_push}/Products.CMFEditions.git
+url = ${settings:plone}/Products.CMFEditions.git
+
+[Products.CMFPlacefulWorkflow]
+branch = master
+pushurl = ${settings:plone_push}/Products.CMFPlacefulWorkflow.git
+url = ${settings:plone}/Products.CMFPlacefulWorkflow.git
+
+[Products.CMFPlone]
+branch = master
+pushurl = ${settings:plone_push}/Products.CMFPlone.git
+url = ${settings:plone}/Products.CMFPlone.git
+
+[Products.CMFUid]
+branch = master
+pushurl = ${settings:zope_push}/Products.CMFUid.git
+url = ${settings:zope}/Products.CMFUid.git
+
+[Products.DateRecurringIndex]
+branch = master
+pushurl = ${settings:collective_push}/Products.DateRecurringIndex.git
+url = ${settings:collective}/Products.DateRecurringIndex.git
+
+[Products.DCWorkflow]
+branch = master
+pushurl = ${settings:zope_push}/Products.DCWorkflow.git
+url = ${settings:zope}/Products.DCWorkflow.git
+
+[Products.ExtendedPathIndex]
+branch = master
+pushurl = ${settings:plone_push}/Products.ExtendedPathIndex.git
+url = ${settings:plone}/Products.ExtendedPathIndex.git
+
+[Products.ExternalEditor]
+branch = master
+pushurl = ${settings:zope_push}/Products.ExternalEditor.git
+url = ${settings:zope}/Products.ExternalEditor.git
+
+[Products.ExternalMethod]
+branch = master
+pushurl = ${settings:zope_push}/Products.ExternalMethod.git
+url = ${settings:zope}/Products.ExternalMethod.git
+
+[Products.GenericSetup]
+branch = master
+pushurl = ${settings:zope_push}/Products.GenericSetup.git
+url = ${settings:zope}/Products.GenericSetup.git
+
+[Products.isurlinportal]
+branch = master
+pushurl = ${settings:plone_push}/Products.isurlinportal.git
+url = ${settings:plone}/Products.isurlinportal.git
+
+[Products.MailHost]
+branch = master
+pushurl = ${settings:zope_push}/Products.MailHost
+url = ${settings:zope}/Products.MailHost
+
+[Products.MimetypesRegistry]
+branch = master
+pushurl = ${settings:plone_push}/Products.MimetypesRegistry.git
+url = ${settings:plone}/Products.MimetypesRegistry.git
+
+[Products.PlonePAS]
+branch = master
+pushurl = ${settings:plone_push}/Products.PlonePAS.git
+url = ${settings:plone}/Products.PlonePAS.git
+
+[Products.PluggableAuthService]
+branch = master
+pushurl = ${settings:zope_push}/Products.PluggableAuthService.git
+url = ${settings:zope}/Products.PluggableAuthService.git
+
+[Products.PluginRegistry]
+branch = master
+pushurl = ${settings:zope_push}/Products.PluginRegistry.git
+url = ${settings:zope}/Products.PluginRegistry.git
+
+[Products.PortalTransforms]
+branch = master
+pushurl = ${settings:plone_push}/Products.PortalTransforms.git
+url = ${settings:plone}/Products.PortalTransforms.git
+
+[Products.PythonScripts]
+branch = master
+pushurl = ${settings:zope_push}/Products.PythonScripts
+url = ${settings:zope}/Products.PythonScripts
+
+[Products.Sessions]
+branch = master
+pushurl = ${settings:zope_push}/Products.Sessions
+url = ${settings:zope}/Products.Sessions
+
+[Products.SiteErrorLog]
+branch = master
+pushurl = ${settings:zope_push}/Products.SiteErrorLog
+url = ${settings:zope}/Products.SiteErrorLog
+
+[Products.statusmessages]
+branch = master
+pushurl = ${settings:plone_push}/Products.statusmessages.git
+url = ${settings:plone}/Products.statusmessages.git
+
+[Products.TemporaryFolder]
+branch = master
+pushurl = ${settings:zope_push}/Products.TemporaryFolder
+url = ${settings:zope}/Products.TemporaryFolder
+
+[Products.ZCatalog]
+branch = master
+pushurl = ${settings:zope_push}/Products.ZCatalog
+url = ${settings:zope}/Products.ZCatalog
+
+[Products.ZODBMountPoint]
+branch = master
+pushurl = ${settings:zope_push}/Products.ZODBMountPoint
+url = ${settings:zope}/Products.ZODBMountPoint
+
+[Products.ZopeVersionControl]
+branch = master
+pushurl = ${settings:zope_push}/Products.ZopeVersionControl.git
+url = ${settings:zope}/Products.ZopeVersionControl.git
+
+[Record]
+branch = master
+pushurl = ${settings:zope_push}/Record
+url = ${settings:zope}/Record
+
+[repoze.xmliter]
+branch = master
+pushurl = git@github.com:repoze/repoze.xmliter.git
+url = https://github.com/repoze/repoze.xmliter.git
+
+[RestrictedPython]
+branch = master
+pushurl = ${settings:zope_push}/RestrictedPython
+url = ${settings:zope}/RestrictedPython
+
+[robotsuite]
+branch = master
+pushurl = ${settings:collective_push}/robotsuite.git
+url = ${settings:collective}/robotsuite.git
+
+[z3c.batching]
+branch = master
+pushurl = ${settings:zope_push}/z3c.batching.git
+url = ${settings:zope}/z3c.batching.git
+
+[z3c.caching]
+branch = master
+pushurl = ${settings:zope_push}/z3c.caching.git
+url = ${settings:zope}/z3c.caching.git
+
+[z3c.form]
+branch = master
+pushurl = ${settings:zope_push}/z3c.form.git
+url = ${settings:zope}/z3c.form.git
+
+[z3c.formwidget.query]
+branch = master
+pushurl = ${settings:zope_push}/z3c.formwidget.query.git
+url = ${settings:zope}/z3c.formwidget.query.git
+
+[z3c.relationfield]
+branch = master
+pushurl = ${settings:zope_push}/z3c.relationfield.git
+url = ${settings:zope}/z3c.relationfield.git
+
+[zExceptions]
+branch = master
+pushurl = ${settings:zope_push}/zExceptions
+url = ${settings:zope}/zExceptions
+
+[ZODB]
+branch = master
+pushurl = ${settings:zope_push}/ZODB
+url = ${settings:zope}/ZODB
+
+[zodbpickle]
+branch = master
+url = ${settings:zope}/zodbpickle
+
+[zodbupdate]
+branch = master
+pushurl = ${settings:zope_push}/zodbupdate.git
+url = ${settings:zope}/zodbupdate.git
+
+[zodbverify]
+branch = master
+pushurl = ${settings:plone_push}/zodbverify.git
+url = ${settings:plone}/zodbverify.git
+
+[Zope]
+branch = master
+pushurl = ${settings:zope_push}/Zope.git
+url = ${settings:zope}/Zope.git
+
+[zope.annotation]
+branch = master
+url = ${settings:zope}/zope.annotation
+
+[zope.browser]
+branch = master
+url = ${settings:zope}/zope.browser
+
+[zope.browsermenu]
+branch = master
+url = ${settings:zope}/zope.browsermenu
+
+[zope.browserpage]
+branch = master
+url = ${settings:zope}/zope.browserpage
+
+[zope.browserresource]
+branch = master
+url = ${settings:zope}/zope.browserresource
+
+[zope.component]
+branch = master
+url = ${settings:zope}/zope.component
+
+[zope.configuration]
+branch = master
+url = ${settings:zope}/zope.configuration
+
+[zope.container]
+branch = master
+url = ${settings:zope}/zope.container
+
+[zope.contentprovider]
+branch = master
+url = ${settings:zope}/zope.contentprovider
+
+[zope.contenttype]
+branch = master
+url = ${settings:zope}/zope.contenttype
+
+[zope.deferredimport]
+branch = master
+url = ${settings:zope}/zope.deferredimport
+
+[zope.dottedname]
+branch = master
+url = ${settings:zope}/zope.dottedname
+
+[zope.event]
+branch = master
+url = ${settings:zope}/zope.event
+
+[zope.exceptions]
+branch = master
+url = ${settings:zope}/zope.exceptions
+
+[zope.filerepresentation]
+branch = master
+url = ${settings:zope}/zope.filerepresentation
+
+[zope.globalrequest]
+branch = master
+pushurl = ${settings:zope_push}/zope.globalrequest
+url = ${settings:zope}/zope.globalrequest
+
+[zope.i18n]
+branch = master
+url = ${settings:zope}/zope.i18n
+
+[zope.i18nmessageid]
+branch = master
+url = ${settings:zope}/zope.i18nmessageid
+
+[zope.interface]
+branch = master
+url = ${settings:zope}/zope.interface
+
+[zope.lifecycleevent]
+branch = master
+url = ${settings:zope}/zope.lifecycleevent
+
+[zope.location]
+branch = master
+url = ${settings:zope}/zope.location
+
+[zope.pagetemplate]
+branch = master
+url = ${settings:zope}/zope.pagetemplate
+
+[zope.processlifetime]
+branch = master
+url = ${settings:zope}/zope.processlifetime
+
+[zope.proxy]
+branch = master
+url = ${settings:zope}/zope.proxy
+
+[zope.ptresource]
+branch = master
+url = ${settings:zope}/zope.ptresource
+
+[zope.publisher]
+branch = master
+url = ${settings:zope}/zope.publisher
+
+[zope.schema]
+branch = master
+url = ${settings:zope}/zope.schema
+
+[zope.security]
+branch = master
+url = ${settings:zope}/zope.security
+
+[zope.sendmail]
+branch = master
+url = ${settings:zope}/zope.sendmail
+
+[zope.sequencesort]
+branch = master
+url = ${settings:zope}/zope.sequencesort
+
+[zope.site]
+branch = master
+url = ${settings:zope}/zope.site
+
+[zope.size]
+branch = master
+url = ${settings:zope}/zope.size
+
+[zope.structuredtext]
+branch = master
+url = ${settings:zope}/zope.structuredtext
+
+[zope.tal]
+branch = master
+url = ${settings:zope}/zope.tal
+
+[zope.tales]
+branch = master
+url = ${settings:zope}/zope.tales
+
+[zope.testbrowser]
+branch = master
+url = ${settings:zope}/zope.testbrowser
+
+[zope.testing]
+branch = master
+url = ${settings:zope}/zope.testing
+
+[zope.testrunner]
+branch = master
+url = ${settings:zope}/zope.testrunner
+
+[zope.traversing]
+branch = master
+url = ${settings:zope}/zope.traversing
+
+[zope.viewlet]
+branch = master
+url = ${settings:zope}/zope.viewlet


### PR DESCRIPTION
Add scripts to create mxdev compatible ini files from sources.cfg and checkouts.cfg.

This feature is useful with the mxdev `include` feature, available since mxdev 3.1.0 and done at the Kitchen Sprint 2023 in Völs. See: https://github.com/mxstack/mxdev/pull/37

TODO
- [x] integrate it in tox release workflow.
- [ ] document somewhere
- [x] test a with mxdev
