### PR TITLE
Update various versions for 6.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pip==23.3.1
-setuptools==69.0.2
+pip==23.3.2
+setuptools==69.0.3
 wheel==0.42.0
 zc.buildout==3.0.1
 

--- a/versions-extra.cfg
+++ b/versions-extra.cfg
@@ -3,8 +3,8 @@
 # that pull in ever more dependencies.
 # Note: version pins in this file can be removed at any time.
 [versions]
-argcomplete = 3.1.6
-argh = 0.30.4
+argcomplete = 3.2.1
+argh = 0.31.0
 bleach = 6.1.0
 build = 1.0.3
 cachecontrol = 0.13.1
@@ -14,14 +14,14 @@ click-default-group = 1.2.4
 cmarkgfm = 2022.10.27
 colorama = 0.4.6
 commonmark = 0.9.1
-configparser = 5.3.0
+configparser = 6.0.0
 Deprecated = 1.2.14
-distro = 1.8.0
+distro = 1.9.0
 fancycompleter = 0.9.1
 filelock = 3.13.1
 gitdb = 4.0.11
 grpcio-tools = 1.59.0
-GitPython = 3.1.40
+GitPython = 3.1.41
 httplib2 = 0.22.0
 i18ndude = 6.1.0
 incremental = 22.10.0
@@ -30,10 +30,10 @@ keyring = 24.3.0
 lockfile = 0.12.2
 markdown-it-py = 3.0.0
 mdurl = 0.1.2
-more-itertools = 10.1.0
+more-itertools = 10.2.0
 msgpack = 1.0.7
-mxdev = 3.0.0
-nh3 = 0.2.14
+mxdev = 3.1.0
+nh3 = 0.2.15
 oauthlib = 3.2.2
 pdbpp = 0.10.3
 pep440 = 0.1.2

--- a/versions.cfg
+++ b/versions.cfg
@@ -13,8 +13,8 @@ extends = https://zopefoundation.github.io/Zope/releases/5.9/versions.cfg
 [versions]
 # Basics
 # !! keep in sync with requirements.txt !!
-pip = 23.3.1
-setuptools = 69.0.2
+pip = 23.3.2
+setuptools = 69.0.3
 wheel = 0.42.0
 zc.buildout = 3.0.1
 
@@ -22,6 +22,8 @@ zc.buildout = 3.0.1
 nt-svcutils = 2.13.0
 
 # OVERRIDES
+# For Python 3.12.1+ support:
+zope.testrunner = 6.2.1
 
 # CORE PLONE.
 # These packages are what you get when installing Plone plus test dependencies,
@@ -184,25 +186,25 @@ zope.sendmail = 6.0
 # These packages are what you get when installing Plone and its tests,
 # but are NOT managed by closely related communities.
 async-generator = 1.10
-attrs = 23.1.0
+attrs = 23.2.0
 backports.cached-property = 1.0.2
 cryptography = 41.0.7
 click = 8.1.7
 cssselect = 1.2.0
 decorator = 5.1.1
 exceptiongroup = 1.2.0
-feedparser = 6.0.10
+feedparser = 6.0.11
 furl = 2.1.3
 future = 0.18.3
 gunicorn = 21.2.0
 h11 = 0.14.0
-importlib-resources = 5.13.0
+importlib-resources = 6.1.1
 jsonschema = 4.20.0
-jsonschema-specifications = 2023.11.2
+jsonschema-specifications = 2023.12.1
 jeepney = 0.8.0
-lxml = 4.9.3
+lxml = 4.9.4
 manuel = 1.12.4
-Markdown = 3.5.1
+Markdown = 3.5.2
 mock = 5.1.0
 orderedmultidict = 1.0.1
 outcome = 1.3.0post0
@@ -218,7 +220,7 @@ PySocks = 1.7.1
 python-dateutil = 2.8.2
 python-dotenv = 1.0.0
 PyYAML = 6.0.1
-referencing = 0.31.1
+referencing = 0.32.1
 responses = 0.24.1
 robotframework = 6.0.2
 # robotframework >= 6.1 is only supported with robotframwork-lsp >= 1.11.0,
@@ -240,15 +242,15 @@ simplejson = 3.19.2
 sniffio = 1.3.0
 sortedcontainers = 2.4.0
 toml = 0.10.2
-trio = 0.23.1
+trio = 0.24.0
 trio-websocket = 0.11.1
 types-PyYAML = 6.0.12.10
 types-toml = 0.10.8.5
-typing-extensions = 4.8.0
-Unidecode = 1.3.7
+typing-extensions = 4.9.0
+Unidecode = 1.3.8
 urllib3-secure-extra = 0.1.0
 watchdog = 3.0.0
-wcwidth = 0.2.12
+wcwidth = 0.2.13
 webresource = 1.2
 wrapt = 1.16.0
 wsproto = 1.2.0


### PR DESCRIPTION
NOT included are a new lxml (test error in diazo), Pillow (errors in plone.scale), and various robotframework updates (did not want to try yet).