### PR TITLE
Uses TZ = UTC in buildout

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -126,6 +126,15 @@ recipe = collective.xmltestreport
 eggs = ${buildout:test-eggs}
 defaults = ['--auto-color', '--auto-progress', '--ignore_dir=.git', '--ignore_dir=bower_components', '--ignore_dir=node_modules']
 environment = environment
+initialization =
+# Ensures that tests using datetime will work locally on machines using TZ = GMT
+    os.environ['TZ'] = 'UTC'
+    import time
+    try:
+        time.tzset()
+    except AttributeError:
+        # function not available on Windows
+        pass
 
 [robot]
 recipe = zc.recipe.egg


### PR DESCRIPTION
This ensures that tests using datetime will work locally on machines using TZ = GMT

It's the same thing that is in Plone 5.2 but was lost in Plone 6:

https://github.com/plone/buildout.coredev/blob/5.2/tests.cfg#L150-L158