### PR TITLE
Checkout Zope and use its versions.cfg for testing.

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -10,6 +10,7 @@ auto-checkout =
     plone.app.upgrade
     Products.CMFPlone
 # These packages are manually added, or automatically added by mr.roboto:
+    Zope
     plone.restapi
     plone.volto
     plone.app.contenttypes

--- a/versions.cfg
+++ b/versions.cfg
@@ -5,9 +5,9 @@
 # Note: version pins in this file should only be removed in a new minor version of Plone.
 
 # Based on latest development Zope:
-# extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
+extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
 # Based on released Zope:
-extends = https://zopefoundation.github.io/Zope/releases/5.9/versions.cfg
+# extends = https://zopefoundation.github.io/Zope/releases/5.9/versions.cfg
 
 
 [versions]


### PR DESCRIPTION
Some recent Zope changes may require changes in Plone.  Let's see what breaks.

Locally I already saw test failures in `plone.dexterity`, which should be easy to fix either in the tests or in Zope.