### PR TITLE
gh-actions: use macos-12 instead of macos-latest. [6.1]

### DIFF
--- a/.github/workflows/run-buildout.yml
+++ b/.github/workflows/run-buildout.yml
@@ -13,7 +13,7 @@ jobs:
         os:
         - ubuntu-latest
         - windows-latest
-        - macos-latest
+        - macos-12
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -35,12 +35,13 @@ jobs:
         restore-keys: |
           eggs-${{ matrix.python-version }}-${{ runner.os }}-
     - name: Run buildout if Mac
-      if: matrix.os == 'macos-latest'
+      if: startsWith(matrix.os, 'macos')
       run: |
         # MacOS on gh-actions cannot install MarkupSafe on Py 3.10, see https://github.com/plone/buildout.coredev/issues/799
+        # Also problems with charset-normalizer on all Python versions now it seems, see https://github.com/plone/buildout.coredev/issues/922
         export _PYTHON_HOST_PLATFORM="macosx-11-x86_64"
         buildout buildout:git-clone-depth=1
     - name: Run buildout
-      if: matrix.os != 'macos-latest'
+      if: (!startsWith(matrix.os, 'macos'))
       run: |
         buildout buildout:git-clone-depth=1


### PR DESCRIPTION
Latest is switching to 14 and this is causing problems. See various tries in https://github.com/plone/buildout.coredev/pull/923 Fixes https://github.com/plone/buildout.coredev/issues/922