### PR TITLE
Bump zope.testrunner

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -122,7 +122,7 @@ ROBOTSUITE_APPEND_OUTPUT_XML = 1
 zope_i18n_compile_mo_files = true
 
 [test]
-recipe = collective.xmltestreport
+recipe = zc.recipe.testrunner
 eggs = ${buildout:test-eggs}
 defaults = ['--auto-color', '--auto-progress', '--ignore_dir=.git', '--ignore_dir=bower_components', '--ignore_dir=node_modules']
 environment = environment

--- a/versions.cfg
+++ b/versions.cfg
@@ -24,8 +24,8 @@ nt-svcutils = 2.13.0
 # OVERRIDES
 certifi = 2024.2.2
 mr.developer = 2.0.2
-# For Python 3.12.1+ support:
-zope.testrunner = 6.2.1
+# For Python 3.12.1+ support, `--xml` and native namespaces (PEP 440):
+zope.testrunner = 6.4
 
 # CORE PLONE.
 # These packages are what you get when installing Plone plus test dependencies,


### PR DESCRIPTION
Add support for the `--xml` option and PEP 440 as well.

We have to drop `collective.xmltestreport` as the code from it is already merged with the newer version of `zope.testrunner` ✨ 

It needs https://github.com/plone/jenkins.plone.org/pull/357 merged and deployed 🤖 