### PR TITLE
Add instance-cmfplone buildout part.

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -12,6 +12,7 @@ devtool-eggs =
     pdbpp
 
 parts +=
+    instance-cmfplone
     robot
     zopescripts
     zopepy
@@ -40,6 +41,17 @@ eggs +=
     ${buildout:devtool-eggs}
 environment-vars =
     zope_i18n_compile_mo_files true
+
+
+[instance-cmfplone]
+# Separate instance for only Products.CMFPlone
+# Some packages you may want to temporarily add locally when testing,
+# are plone.app.upgrade and plone.app.caching.
+recipe = plone.recipe.zope2instance
+user = ${buildout:plone-user}
+eggs =
+    Products.CMFPlone
+    ${buildout:custom-eggs}
 
 
 [zopescripts]


### PR DESCRIPTION
Useful for testing: for example how else are you going to test Plone 6.1 in coredev without plone.app.discussion.