### PR TITLE
Distributions PLIP config: add zeo with 5 clients.

### DIFF
--- a/plips/plip-distributions.cfg
+++ b/plips/plip-distributions.cfg
@@ -18,6 +18,7 @@ auto-checkout +=
     plone.exportimport
     plone.classicui
     plone.volto
+    plone.app.testing
 
 test-eggs +=
     plone.distribution
@@ -72,9 +73,11 @@ eggs =
     ${buildout:custom-eggs}
 
 [sources]
+Products.CMFPlone                   = git ${remotes:plone}/Products.CMFPlone.git pushurl=${remotes:plone_push}/Products.CMFPlone.git branch=distributions
 plone.distribution                  = git ${remotes:plone}/plone.distribution.git pushurl=${remotes:plone_push}/plone.distribution.git branch=main
 plone.exportimport                  = git ${remotes:plone}/plone.exportimport.git pushurl=${remotes:plone_push}/plone.exportimport.git branch=main
 plone.classicui                     = git ${remotes:plone}/plone.classicui.git pushurl=${remotes:plone_push}/plone.classicui.git branch=main
+plone.app.testing                   = git ${remotes:plone}/plone.app.testing.git pushurl=${remotes:plone_push}/plone.app.testing.git branch=distributions
 # plone.volto                         = git ${remotes:plone}/plone.volto.git pushurl=${remotes:plone_push}/plone.volto.git branch=main
 
 [versions]

--- a/plips/plip-distributions.cfg
+++ b/plips/plip-distributions.cfg
@@ -2,16 +2,74 @@
 # See https://github.com/plone/Products.CMFPlone/issues/3854
 
 extends = plipbase.cfg
+# Add a zeoserver and zeoclients for each main package.
+# Each uses a different port number, so you can run
+# them side by side and compare.
+parts +=
+    zeoserver
+    zeoclient
+    zeoclient-cmfplone
+    zeoclient-distribution
+    zeoclient-volto
+    zeoclient-classic
 
 auto-checkout +=
     plone.distribution
     plone.exportimport
     plone.classicui
-# plone.volto
+    plone.volto
 
 test-eggs +=
     plone.distribution
     plone.exportimport
+
+[zeoserver]
+recipe = plone.recipe.zeoserver
+zeo-address = 127.0.0.1:7600
+zeo-var = ${conf:var}
+blob-storage = ${conf:var}/blobstorage
+file-storage = ${conf:var}/filestorage/Data.fs
+zeo-log = ${conf:var}/zeoserver.log
+socket-name = ${conf:var}/zeo.zdsock
+pid-file = ${conf:var}/zeoserver.pid
+
+[zeoclient]
+<= instance
+http-address = 8080
+zeo-client = true
+zeo-address = ${zeoserver:zeo-address}
+shared-blob = on
+eggs =
+    Plone
+    ${buildout:custom-eggs}
+
+[zeoclient-cmfplone]
+<= zeoclient
+http-address = 8081
+eggs =
+    Products.CMFPlone
+    ${buildout:custom-eggs}
+
+[zeoclient-distribution]
+<= zeoclient
+http-address = 8082
+eggs =
+    plone.distribution
+    ${buildout:custom-eggs}
+
+[zeoclient-volto]
+<= zeoclient
+http-address = 8083
+eggs =
+    plone.volto
+    ${buildout:custom-eggs}
+
+[zeoclient-classic]
+<= zeoclient
+http-address = 8084
+eggs =
+    plone.classicui
+    ${buildout:custom-eggs}
 
 [sources]
 plone.distribution                  = git ${remotes:plone}/plone.distribution.git pushurl=${remotes:plone_push}/plone.distribution.git branch=main

--- a/plips/plipbase.cfg
+++ b/plips/plipbase.cfg
@@ -13,8 +13,11 @@ sources-dir = ../src
 installed = ../.installed.cfg
 docs-directory = ../documentation
 
-[instance]
+[conf]
 var = ${buildout:directory}/../var
+
+[instance]
+var = ${conf:var}
 
 [environment]
 BUILDOUT_DIR = ${buildout:directory}/..


### PR DESCRIPTION
One zeoclient for each of: Plone, Products.CMFPlone, plone.distribution, plone.volto, plone.classicui. So only one of those packages in the eggs.
Then you can run 'bin/zeoserver start' and then start however much of those zeoclients you want. Port numbers between 8080 and 8084.