### PR TITLE
Fix typo in a comment in `checkouts.cfg`

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -2,7 +2,7 @@
 always-checkout = force
 # always-checkout = false
 auto-checkout =
-# These packages are always checkout out:
+# These packages are always checked out:
     docs
     mockup
     Plone


### PR DESCRIPTION
For something this trivial, fixing a typo in a comment, does it need a formal change log entry?