### PR TITLE
gh-actions 5.2: run on macos-12 instead of 11.

### DIFF
--- a/.github/workflows/run-buildout-38.yml
+++ b/.github/workflows/run-buildout-38.yml
@@ -11,7 +11,7 @@ jobs:
         os:
         - ubuntu-20.04
         - windows-2022
-        - macos-11
+        - macos-12
     runs-on: ${{ matrix.os }}
     steps:
     - name: locale


### PR DESCRIPTION
11 is not available anymore.
Jobs keeps waiting: https://github.com/plone/buildout.coredev/actions/runs/10167697280/job/28120649924 See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories