### PR TITLE
5.2: remove all checkouts.

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -2,9 +2,9 @@
 always-checkout = force
 # always-checkout = false
 auto-checkout =
-# These packages are always checkout out:
-    Plone
-    plone.app.locales
-    plone.app.upgrade
-    Products.CMFPlone
+# Plone 5.2 is out of maintenance support, so let's not even check out the regular packages.
+#    Plone
+#    plone.app.locales
+#    plone.app.upgrade
+#    Products.CMFPlone
 # Automatically added by mr.roboto after PR merge:


### PR DESCRIPTION
I released 5.2.15 today.
5.2 is now really out of maintenance mode, so we should test the released packages.

The only changes that are expected to come in and still need a release, would be security fixes. But there it may be enough to update a single package version, nothing else. So I also won't do what I usually do after a release: update the profile version in the metadata.xml of CMFPlone, plus dummy upgrade step.