### PR TITLE
Pin docutils to 0.21.2

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -23,7 +23,7 @@ nt-svcutils = 2.13.0
 
 # OVERRIDES
 # Zope uses an older version for its Sphinx theme, which Plone does not use
-docutils = 0.21.2
+docutils = 0.20.1
 
 # CORE PLONE.
 # These packages are what you get when installing Plone plus test dependencies,

--- a/versions.cfg
+++ b/versions.cfg
@@ -22,6 +22,8 @@ zc.buildout = 3.0.1
 nt-svcutils = 2.13.0
 
 # OVERRIDES
+# Zope uses an older version for its Sphinx theme, which Plone does not use
+docutils = 0.21.2
 
 # CORE PLONE.
 # These packages are what you get when installing Plone plus test dependencies,


### PR DESCRIPTION
Zope uses an older version of docutils for its Sphinx theme, which Plone does not use.

See https://github.com/plone/plone.restapi/pull/1798

Backport of https://github.com/plone/buildout.coredev/pull/942