### PR TITLE
Update to zc.buildout 3.1.0 and latests pip/setuptools/wheel. [6.1]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-pip==24.0
-setuptools==69.5.1
-wheel==0.43.0
-zc.buildout==3.0.1
+pip==24.2
+setuptools==74.0.0
+wheel==0.44.0
+zc.buildout==3.1.0
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -13,10 +13,10 @@ extends = https://zopefoundation.github.io/Zope/releases/5.10/versions.cfg
 [versions]
 # Basics
 # !! keep in sync with requirements.txt !!
-pip = 24.0
-setuptools = 69.5.1
-wheel = 0.43.0
-zc.buildout = 3.0.1
+pip = 24.2
+setuptools = 74.0.0
+wheel = 0.44.0
+zc.buildout = 3.1.0
 
 # windows specific
 nt-svcutils = 2.13.0


### PR DESCRIPTION
`zc.buildout` 3.1.0 was released today with my fixes from https://github.com/buildout/buildout/pull/649 so it finally works with setuptools 70+.
So let's test with all the latest goodness.