### PR TITLE
Update to zc.buildout 3.1.1 and setuptools 75.1.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip==24.2
-setuptools==74.0.0
+setuptools==75.1.0
 wheel==0.44.0
-zc.buildout==3.1.0
+zc.buildout==3.1.1
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -14,9 +14,9 @@ extends = https://zopefoundation.github.io/Zope/releases/5.10/versions.cfg
 # Basics
 # !! keep in sync with requirements.txt !!
 pip = 24.2
-setuptools = 74.0.0
+setuptools = 75.1.0
 wheel = 0.44.0
-zc.buildout = 3.1.0
+zc.buildout = 3.1.1
 
 # windows specific
 nt-svcutils = 2.13.0


### PR DESCRIPTION
Note that setuptools 75 removes the deprecated 'upload' and 'register' commands from 'setup.py', but we should not need that. At least zest.releaser calls 'twine' to upload or register to PyPI.