### PR TITLE
Use zc.buildout 3.2.0 to optionally extend local.cfg. [6.1]

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -4,6 +4,10 @@ extends =
     versions-extra.cfg
     bare.cfg
 
+# New in zc.buildout 3.2.0: optionally extend a local (non-git) config file:
+optional-extends =
+    local.cfg
+
 extensions +=
     plone.versioncheck
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip==24.2
 setuptools==75.1.0
 wheel==0.44.0
-zc.buildout==3.1.1
+zc.buildout==3.2.0
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -16,7 +16,7 @@ extends = https://zopefoundation.github.io/Zope/releases/5.10/versions.cfg
 pip = 24.2
 setuptools = 75.1.0
 wheel = 0.44.0
-zc.buildout = 3.1.1
+zc.buildout = 3.2.0
 
 # windows specific
 nt-svcutils = 2.13.0


### PR DESCRIPTION
I added this option in https://github.com/buildout/buildout/pull/665

For inspiration, here is part of my own `local.cfg`:

```
[buildout]
develop +=
    /Users/maurits/community/zest.releaser
auto-checkout +=
    plone.releaser
custom-eggs +=
    pdbpp

allow-picked-versions = true

[remotes]
plone = git@github.com:plone
collective = git@github.com:collective
zope = git@github.com:zopefoundation

[versions]
zest.releaser =
```

Originally the file started with these lines:

```
[buildout]
extends =
   buildout.cfg
```

and then I always ran `bin/buildout -c local.cfg`. When I then wanted to use `plips/plip-distributions.cfg`, it got tricky because this was in a different directory, so I needed actual changes in git. Now it works in both cases thanks to the `optional-extends`.