### PR TITLE
Revert "Update versions for `robotframework-browser = 18.8.1` [6.0]"

### DIFF
--- a/versions-extra.cfg
+++ b/versions-extra.cfg
@@ -20,6 +20,7 @@ distro = 1.9.0
 fancycompleter = 0.9.1
 filelock = 3.13.4
 gitdb = 4.0.11
+grpcio-tools = 1.59.0
 GitPython = 3.1.43
 httplib2 = 0.22.0
 i18ndude = 6.2.1
@@ -69,3 +70,7 @@ zestreleaser.towncrier = 1.3.0
 zodbverify = 1.2.0
 zope.mkzeoinstance = 5.1.1
 ZopeUndo = 6.0
+
+[versionannotations]
+grpcio-tools =
+    Requirement of robotframework-browser: grpcio-tools==1.59.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -212,7 +212,7 @@ outcome = 1.3.0post0
 overrides = 7.7.0
 piexif = 1.1.3
 Pillow = 9.5.0
-prompt-toolkit = 3.0.47
+prompt-toolkit = 2.0.10
 py = 1.11.0
 PyJWT = 2.8.0
 pyOpenSSL = 24.1.0
@@ -226,11 +226,11 @@ responses = 0.24.1
 robotframework = 6.0.2
 # robotframework >= 6.1 is only supported with robotframwork-lsp >= 1.11.0,
 # but https://github.com/robocorp/robotframework-lsp/issues/947
-robotframework-assertion-engine = 3.0.3
-robotframework-browser = 18.8.1
-robotframework-debuglibrary = 2.5.0
 robotframework-lsp = 1.10.1
-robotframework-pythonlibcore = 4.4.1
+robotframework-assertion-engine = 2.0.0
+robotframework-browser = 17.5.2
+robotframework-debuglibrary = 2.3.0
+robotframework-pythonlibcore = 4.2.0
 robotframework-selenium2library = 3.0.0
 robotframework-selenium2screenshots = 0.8.1
 robotframework-seleniumlibrary = 6.1.3
@@ -262,5 +262,7 @@ pkgutil-resolve-name = 1.3.10
 
 [versionannotations]
 # keep this alphabetical please
+prompt-toolkit =
+    Requirement of robotframework-debuglibrary: prompt-toolkit<3,>=2
 selenium =
     robotframework-seleniumlibrary 6.1.0 is incompatible with 4.10.0. See https://github.com/robotframework/SeleniumLibrary/issues/1835


### PR DESCRIPTION
Reverts plone/buildout.coredev#949 due to flaky robot tests