### PR TITLE
GHA: test on macos-latest.

### DIFF
--- a/.github/workflows/run-buildout.yml
+++ b/.github/workflows/run-buildout.yml
@@ -13,7 +13,7 @@ jobs:
         os:
         - ubuntu-latest
         - windows-latest
-        - macos-12
+        - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
We were using macos-12. The macOS 12 runner image will be removed by December 3rd, 2024. So let's try latest, which currently would be macos-15.