### PR TITLE
Create a `ci.cfg` for minimal CI config

### DIFF
--- a/ci.cfg
+++ b/ci.cfg
@@ -1,0 +1,6 @@
+[buildout]
+extends =
+    bare.cfg
+auto-checkout -=
+    docs
+    mockup

--- a/ci.cfg
+++ b/ci.cfg
@@ -4,3 +4,6 @@ extends =
 auto-checkout -=
     docs
     mockup
+parts +=
+#   test is installed in bare.cfg
+    robot


### PR DESCRIPTION
Note: I've temporary tricked jenkins PR-6.1 jobs config in order to test this:

```bash
BUILDOUT_CFG="$([[ -s 'ci.cfg' ]] && echo 'ci.cfg' || echo 'buildout.cfg')"
buildout buildout:git-clone-depth=1 -c $BUILDOUT_CFG
```
