### PR TITLE
6.0: drop Python 3.8, drop macos-12, update Zope/pip/st/buildout.

### DIFF
--- a/.github/workflows/bare.yml
+++ b/.github/workflows/bare.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         python-version:
         # Use the oldest supported Python version, as that may pull in more versions.
-        - "3.8"
+        - "3.9"
     runs-on: ubuntu-latest
     steps:
     - name: locale

--- a/.github/workflows/run-buildout.yml
+++ b/.github/workflows/run-buildout.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - "3.8"
         - "3.9"
         - "3.10"
         - "3.11"
@@ -15,7 +14,7 @@ jobs:
         os:
         - ubuntu-latest
         - windows-latest
-        - macos-12
+        - macos-13
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-pip==24.2
-setuptools==74.0.0
-wheel==0.44.0
-zc.buildout==3.1.0
+pip==24.3.1
+setuptools==75.3.0
+wheel==0.45.1
+zc.buildout==3.3
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -7,23 +7,21 @@
 # Based on latest development Zope:
 # extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
 # Based on released Zope:
-extends = https://zopefoundation.github.io/Zope/releases/5.10/versions.cfg
+extends = https://zopefoundation.github.io/Zope/releases/5.11.1/versions.cfg
 
 
 [versions]
 # Basics
 # !! keep in sync with requirements.txt !!
-pip = 24.2
-setuptools = 74.0.0
-wheel = 0.44.0
-zc.buildout = 3.1.0
+pip = 24.3.1
+setuptools = 75.3.0
+wheel = 0.45.1
+zc.buildout = 3.3
 
 # windows specific
 nt-svcutils = 2.13.0
 
 # OVERRIDES
-# Zope uses an older version for its Sphinx theme, which Plone does not use
-docutils = 0.20.1
 
 # CORE PLONE.
 # These packages are what you get when installing Plone plus test dependencies,


### PR DESCRIPTION
Python 3.8 is out of security support, so I will officially drop it from Plone 6.0 soon.  As we say in the [release schedule](https://plone.org/download/release-schedule): "Plone 6.0 works on Python 3.8, but this Python version reaches end of life in October 2024. At that point, Plone 6 will drop support for Python 3.8."  See also https://github.com/plone/jenkins.plone.org/pull/377

We also need to stop testing on macos-12 as it may fail soon.  See https://github.com/plone/buildout.coredev/issues/967 Updated to macos-13 for now.

Updated pip, setuptools, buildout.
For the moment I kept setuptools at the highest version that still supports Python 3.8, but I want to increase that.  It would break Jenkins currently without the other PR I mentioned.

Update Zope to latest 5.11.1.

I will make this a draft PR, as the `Products.validation` tests fail due to an updated `zope.i18nmessageid`.  I am preparing a workaround for that: https://github.com/plone/Products.validation/pull/14

And plone.base fails, which needs a back port:
https://github.com/plone/plone.base/pull/74