### PR TITLE
Pin newer robotframework-browser; run GHA buildout on Python 3.13

### DIFF
--- a/.github/workflows/run-buildout.yml
+++ b/.github/workflows/run-buildout.yml
@@ -11,6 +11,7 @@ jobs:
         - "3.10"
         - "3.11"
         - "3.12"
+        - "3.13"
         os:
         - ubuntu-latest
         - windows-latest

--- a/versions.cfg
+++ b/versions.cfg
@@ -209,6 +209,7 @@ lxml-html-clean = 0.4.1
 manuel = 1.13.0
 Markdown = 3.7
 mock = 5.1.0
+natsort = 8.4.0
 orderedmultidict = 1.0.1
 outcome = 1.3.0post0
 overrides = 7.7.0
@@ -241,6 +242,7 @@ robotframework-seleniumtestability = 2.1.0
 
 rpds-py = 0.22.3
 SecretStorage = 3.3.3
+seedir = 0.5.0
 selenium = 4.9.1
 sgmllib3k = 1.0.0
 simplejson = 3.19.3

--- a/versions.cfg
+++ b/versions.cfg
@@ -228,7 +228,7 @@ responses = 0.25.3
 
 robotframework = 6.0.2
 robotframework-assertion-engine = 3.0.3
-robotframework-browser = 18.8.1
+robotframework-browser = 18.9.1
 robotframework-debuglibrary = 2.5.0
 # robotframework >= 6.1 is only supported with robotframwork-lsp >= 1.11.0,
 # but https://github.com/robocorp/robotframework-lsp/issues/947


### PR DESCRIPTION
Same robotframework-browser version as on 6.1 now.