### PR TITLE
Use Zope 5.12 [6.1]

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -7,7 +7,7 @@
 # Based on latest development Zope:
 # extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
 # Based on released Zope:
-extends = https://zopefoundation.github.io/Zope/releases/5.11.1/versions.cfg
+extends = https://zopefoundation.github.io/Zope/releases/5.12/versions.cfg
 
 
 [versions]


### PR DESCRIPTION
If I see it correctly, the only differences are actually a new Zope and a new zope.interface.