### PR TITLE
Use zc.buildout 4.0

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -2,7 +2,7 @@
 pip==24.3.1
 setuptools==75.6.0
 wheel==0.45.1
-zc.buildout==3.3
+zc.buildout==4.0
 nt-svcutils==2.13.0
 certifi==2024.12.14
 packaging==24.2

--- a/mx.ini
+++ b/mx.ini
@@ -16,7 +16,8 @@ include =
     mxcheckouts.ini
     mxtests.ini
 version-overrides =
-# You MUST manually keep this in sync with the OVERRIDES in versions.cfg.
+# You MUST manually keep this in sync with the OVERRIDES in versions.cfg
+# plus the packaging pin above it.
     certifi==2024.12.14
     packaging==24.2
     zope.configuration==6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
+packaging==24.2
 pip==24.3.1
 setuptools==75.6.0
 wheel==0.45.1
-zc.buildout==3.3
+zc.buildout==4.0
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -13,10 +13,11 @@ extends = https://zopefoundation.github.io/Zope/releases/5.12/versions.cfg
 [versions]
 # Basics
 # !! keep in sync with requirements.txt !!
+packaging = 24.2
 pip = 24.3.1
 setuptools = 75.6.0
 wheel = 0.45.1
-zc.buildout = 3.3
+zc.buildout = 4.0
 
 # windows specific
 nt-svcutils = 2.13.0
@@ -24,7 +25,6 @@ nt-svcutils = 2.13.0
 # OVERRIDES
 # You MUST manually keep this in sync with the version-overrides in mx.ini.
 certifi = 2024.12.14
-packaging = 24.2
 zope.configuration = 6.0
 waitress = 3.0.2
 webtest = 3.0.2


### PR DESCRIPTION
`packaging` is a dependency of `zc.buildout` 4, so add a pin in `requirements.txt`.

The breaking changes in 4.0 and 4.0.0a1 are expected to be fine for us, mainly dropping outdated Python and setuptools versions.  See [changelog](https://github.com/buildout/buildout/blob/4.0/CHANGES.rst).