### PR TITLE
Use zc.buildout 4.0 [on 6.0]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
+packaging==24.2
 pip==24.3.1
 setuptools==75.6.0
 wheel==0.45.1
-zc.buildout==3.3
+zc.buildout==4.0
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -13,17 +13,17 @@ extends = https://zopefoundation.github.io/Zope/releases/5.12/versions.cfg
 [versions]
 # Basics
 # !! keep in sync with requirements.txt !!
+packaging = 24.2
 pip = 24.3.1
 setuptools = 75.6.0
 wheel = 0.45.1
-zc.buildout = 3.3
+zc.buildout = 4.0
 
 # windows specific
 nt-svcutils = 2.13.0
 
 # OVERRIDES
 certifi = 2024.12.14
-packaging = 24.2
 zope.configuration = 6.0
 waitress = 3.0.2
 WebTest = 3.0.2


### PR DESCRIPTION
`packaging` is a dependency of `zc.buildout` 4, so add a pin in `requirements.txt`.