### PR TITLE
Bump webtest

### DIFF
--- a/versions.cfg
+++ b/versions.cfg
@@ -27,7 +27,7 @@ nt-svcutils = 2.13.0
 certifi = 2024.12.14
 zope.configuration = 6.0
 waitress = 3.0.2
-webtest = 3.0.2
+webtest = 3.0.3
 
 # CORE PLONE.
 # These packages are what you get when installing Plone plus test dependencies,


### PR DESCRIPTION
Version 3.0.2 was yanked, as reported in https://github.com/plone/Products.CMFPlone/issues/4095

Fixes: https://github.com/plone/Products.CMFPlone/issues/4095