### PR TITLE
Update pip, setuptools, zc.buildout, zest.releaser to latest. [6.2]

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,9 +1,9 @@
 -c https://zopefoundation.github.io/Zope/releases/5.12/constraints.txt
 packaging==24.2
-pip==24.3.1
-setuptools==75.6.0
+pip==25.0.1
+setuptools==75.8.2
 wheel==0.45.1
-zc.buildout==4.0
+zc.buildout==4.1
 nt-svcutils==2.13.0
 certifi==2024.12.14
 five.localsitemanager==5.0
@@ -149,7 +149,7 @@ z3c.zcmlhook==2.0
 zc.relation==2.0
 zdaemon==5.1
 ZEO==6.0.0
-zest.releaser==9.2.0
+zest.releaser==9.3.0
 zestreleaser.towncrier==1.3.0
 ZODB3==3.11.0
 zodbupdate==2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 packaging==24.2
-pip==24.3.1
-setuptools==75.6.0
+pip==25.0.1
+setuptools==75.8.2
 wheel==0.45.1
-zc.buildout==4.0
+zc.buildout==4.1
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -14,10 +14,10 @@ extends = https://zopefoundation.github.io/Zope/releases/5.12/versions.cfg
 # Basics
 # !! keep in sync with requirements.txt !!
 packaging = 24.2
-pip = 24.3.1
-setuptools = 75.6.0
+pip = 25.0.1
+setuptools = 75.8.2
 wheel = 0.45.1
-zc.buildout = 4.0
+zc.buildout = 4.1
 
 # windows specific
 nt-svcutils = 2.13.0
@@ -181,7 +181,7 @@ z3c.zcmlhook = 2.0
 zc.relation = 2.0
 zdaemon = 5.1
 ZEO = 6.0.0
-zest.releaser = 9.2.0
+zest.releaser = 9.3.0
 zestreleaser.towncrier = 1.3.0
 ZODB3 = 3.11.0
 zodbupdate = 2.0


### PR DESCRIPTION
zc.buildout and zest.releaser have fixes for discovering entry points.