### PR TITLE
zc.buildout 4.1.3, zest.releaser 9.4.0. [6.2]

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -3,7 +3,7 @@ packaging==24.2
 pip==25.0.1
 setuptools==75.8.2
 wheel==0.45.1
-zc.buildout==4.1
+zc.buildout==4.1.3
 nt-svcutils==2.13.0
 certifi==2024.12.14
 five.localsitemanager==5.0
@@ -149,7 +149,7 @@ z3c.zcmlhook==2.0
 zc.relation==2.0
 zdaemon==5.1
 ZEO==6.0.0
-zest.releaser==9.3.0
+zest.releaser==9.4.0
 zestreleaser.towncrier==1.3.0
 ZODB3==3.11.0
 zodbupdate==2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ packaging==24.2
 pip==25.0.1
 setuptools==75.8.2
 wheel==0.45.1
-zc.buildout==4.1
+zc.buildout==4.1.3
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -17,7 +17,7 @@ packaging = 24.2
 pip = 25.0.1
 setuptools = 75.8.2
 wheel = 0.45.1
-zc.buildout = 4.1
+zc.buildout = 4.1.3
 
 # windows specific
 nt-svcutils = 2.13.0
@@ -181,7 +181,7 @@ z3c.zcmlhook = 2.0
 zc.relation = 2.0
 zdaemon = 5.1
 ZEO = 6.0.0
-zest.releaser = 9.3.0
+zest.releaser = 9.4.0
 zestreleaser.towncrier = 1.3.0
 ZODB3 = 3.11.0
 zodbupdate = 2.0


### PR DESCRIPTION
This should fix any last setuptools/pkg_resources-related problems.