### PR TITLE
Optionally extend local.cfg if it exists. [6.0]

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -4,6 +4,10 @@ extends =
     versions-extra.cfg
     bare.cfg
 
+# New in zc.buildout 3.2.0: optionally extend a local (non-git) config file:
+optional-extends =
+    local.cfg
+
 extensions +=
     plone.versioncheck
 


### PR DESCRIPTION
We already have this in 6.1 since [October](https://github.com/plone/buildout.coredev/pull/951), so also in 6.2. I would like to have it the same in all Plone 6 versions.

cc @petschki because I think you are one of the people who may already be using a `local.cfg` in 6.0, so you would need to slightly change that file locally.