### PR TITLE
Checkout Zope and use its master versions. [6.2]

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -10,6 +10,7 @@ auto-checkout =
     plone.app.upgrade
     Products.CMFPlone
 # These packages are manually added, or automatically added by mr.roboto:
+    Zope
     plone.api
     plone.app.layout
     plone.volto

--- a/mx.ini
+++ b/mx.ini
@@ -18,9 +18,5 @@ include =
 version-overrides =
 # You MUST manually keep this in sync with the OVERRIDES in versions.cfg
 # plus the packaging pin above it.
-    certifi==2024.12.14
     five.localsitemanager==5.0
     packaging==24.2
-    zope.configuration==6.0
-    waitress==3.0.2
-    webtest==3.0.3

--- a/versions.cfg
+++ b/versions.cfg
@@ -5,9 +5,9 @@
 # Note: version pins in this file should only be removed in a new minor version of Plone.
 
 # Based on latest development Zope:
-# extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
+extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
 # Based on released Zope:
-extends = https://zopefoundation.github.io/Zope/releases/5.12/versions.cfg
+# extends = https://zopefoundation.github.io/Zope/releases/5.12/versions.cfg
 
 
 [versions]
@@ -24,11 +24,7 @@ nt-svcutils = 2.13.0
 
 # OVERRIDES
 # You MUST manually keep this in sync with the version-overrides in mx.ini.
-certifi = 2024.12.14
 five.localsitemanager = 5.0
-zope.configuration = 6.0
-waitress = 3.0.2
-webtest = 3.0.3
 
 # CORE PLONE.
 # These packages are what you get when installing Plone plus test dependencies,
@@ -161,7 +157,7 @@ Products.CMFCore = 3.6
 Products.CMFUid = 4.2
 Products.DCWorkflow = 3.0
 Products.ExternalMethod = 6.0
-Products.GenericSetup = 4.0
+Products.GenericSetup = 5.0.0
 Products.MailHost = 6.0
 Products.PluggableAuthService = 3.0
 Products.PluginRegistry = 2.0


### PR DESCRIPTION
We don't have to merge this, I mostly just want to know if the current state of Zope is fine for us.  Also, I just updated a few version pins there that have pkg_resources fixes.

Also in this PR: latest GenericSetup, with pkg_resources fixes.