### PR TITLE
Upgrade to zc.buildout 4.1.12 and setuptools 80.9.0. [6.1]

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,9 +1,9 @@
 -c https://zopefoundation.github.io/Zope/releases/5.13/constraints.txt
 packaging==25.0
 pip==25.1.1
-setuptools==79.0.1
+setuptools==80.9.0
 wheel==0.46.1
-zc.buildout==4.1.10
+zc.buildout==4.1.12
 nt-svcutils==2.13.0
 five.localsitemanager==5.0
 mr.developer==2.0.3

--- a/mxcheckouts.ini
+++ b/mxcheckouts.ini
@@ -30,3 +30,6 @@ use = true
 
 [plone.behavior]
 use = true
+
+[plone.releaser]
+use = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 packaging==25.0
 pip==25.1.1
-setuptools==79.0.1
+setuptools==80.9.0
 wheel==0.46.1
-zc.buildout==4.1.10
+zc.buildout==4.1.12
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -15,9 +15,9 @@ extends = https://zopefoundation.github.io/Zope/releases/5.13/versions.cfg
 # !! keep in sync with requirements.txt !!
 packaging = 25.0
 pip = 25.1.1
-setuptools = 79.0.1
+setuptools = 80.9.0
 wheel = 0.46.1
-zc.buildout = 4.1.10
+zc.buildout = 4.1.12
 
 # windows specific
 nt-svcutils = 2.13.0


### PR DESCRIPTION
This Buildout version has been fixed to be compatible with setuptools 80.