### PR TITLE
Use the 5.x series of plone.app.theming for Plone 6.0.

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -10,6 +10,5 @@ auto-checkout =
     plone.app.upgrade
     Products.CMFPlone
 # These packages are manually added, or automatically added by mr.roboto:
-    plone.app.theming
     plone.behavior
     plone.releaser

--- a/sources.cfg
+++ b/sources.cfg
@@ -71,7 +71,7 @@ plone.app.relationfield             = git ${remotes:plone}/plone.app.relationfie
 plone.app.robotframework            = git ${remotes:plone}/plone.app.robotframework.git pushurl=${remotes:plone_push}/plone.app.robotframework.git branch=master
 plone.app.testing                   = git ${remotes:plone}/plone.app.testing.git pushurl=${remotes:plone_push}/plone.app.testing.git branch=master
 plone.app.textfield                 = git ${remotes:plone}/plone.app.textfield.git pushurl=${remotes:plone_push}/plone.app.textfield.git branch=2.x
-plone.app.theming                   = git ${remotes:plone}/plone.app.theming.git pushurl=${remotes:plone_push}/plone.app.theming.git branch=master
+plone.app.theming                   = git ${remotes:plone}/plone.app.theming.git pushurl=${remotes:plone_push}/plone.app.theming.git branch=5.x
 plone.app.upgrade                   = git ${remotes:plone}/plone.app.upgrade.git pushurl=${remotes:plone_push}/plone.app.upgrade.git branch=master
 plone.app.users                     = git ${remotes:plone}/plone.app.users.git pushurl=${remotes:plone_push}/plone.app.users.git branch=master
 plone.app.uuid                      = git ${remotes:plone}/plone.app.uuid.git pushurl=${remotes:plone_push}/plone.app.uuid.git branch=master


### PR DESCRIPTION
In plone.app.theming I'd like to depend on plone.base > 3.0.0 to use the `is_truthy` utility function while Plone 6.0 has a dependency on plone.base < 2. This would be a breaking change in plone.app.theming and I need to cut a branch 5.x use it in Plone 6.0.

Here it is.