### PR TITLE
Use latest pytest versions. [6.1]

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -117,7 +117,7 @@ Products.MimetypesRegistry==3.0.1
 Products.PlonePAS==8.0.5
 Products.PortalTransforms==4.1.1
 Products.statusmessages==5.0.6
-pytest-plone==1.0.0a1
+pytest-plone==1.0.0a2
 collective.MockMailHost==3.0.0
 collective.monkeypatcher==2.0.0
 collective.recipe.omelette==2.0.0
@@ -160,7 +160,7 @@ zope.componentvocabulary==3.0
 zope.copy==5.0
 zope.intid==5.1
 zope.keyreference==6.1
-zope.pytestlayer==8.2
+zope.pytestlayer==8.3
 zope.ramcache==3.1
 zope.sendmail==6.2
 async-generator==1.10
@@ -216,8 +216,8 @@ pyproject-hooks==1.2.0
 pyroma==4.2
 pyrsistent==0.20.0
 PySocks==1.7.1
-pytest==7.4.4
-pytest-cov==5.0.0
+pytest==8.4.0
+pytest-cov==6.2.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.0
 PyYAML==6.0.2

--- a/versions.cfg
+++ b/versions.cfg
@@ -140,7 +140,7 @@ Products.MimetypesRegistry = 3.0.1
 Products.PlonePAS = 8.0.5
 Products.PortalTransforms = 4.1.1
 Products.statusmessages = 5.0.6
-pytest-plone = 1.0.0a1
+pytest-plone = 1.0.0a2
 
 # CORE DEPENDENCIES: COLLECTIVE.
 # These packages are what you get when installing Plone plus test dependencies,
@@ -192,7 +192,7 @@ zope.componentvocabulary = 3.0
 zope.copy = 5.0
 zope.intid = 5.1
 zope.keyreference = 6.1
-zope.pytestlayer = 8.2
+zope.pytestlayer = 8.3
 zope.ramcache = 3.1
 zope.sendmail = 6.2
 
@@ -252,8 +252,8 @@ pyproject-hooks = 1.2.0
 pyroma = 4.2
 pyrsistent = 0.20.0
 PySocks = 1.7.1
-pytest = 7.4.4
-pytest-cov = 5.0.0
+pytest = 8.4.0
+pytest-cov = 6.2.1
 python-dateutil = 2.9.0.post0
 python-dotenv = 1.1.0
 PyYAML = 6.0.2


### PR DESCRIPTION
Not really used by the coredev buildout AFAIK.
But when I make some local changes in the test setup of `plone.distribution` and `plone.classicui` to use these versions, their tests pass.