### PR TITLE
Add version pin for python-magic [6.1]

### DIFF
--- a/versions-extra.cfg
+++ b/versions-extra.cfg
@@ -36,6 +36,7 @@ PyGithub = 2.6.1
 PyNaCl = 1.5.0
 pyparsing = 3.2.3
 pyrepl = 0.11.4
+python-magic = 0.4.27
 smmap = 5.0.2
 stdlib-list = 0.11.1
 wadllib = 2.0.0


### PR DESCRIPTION
This python distribution is needed in order to allow `Products.MimetypesRegistry` to use it.

See https://github.com/plone/Products.MimetypesRegistry/pull/20

`buildout` in `buildout.coredev` does not allow unpinned versions, so we have to pin it before we can test the above MR in Jenkins.

Note that this should also be ported to `6.0` and `6.2` branches, but first let's agree if we want to ever get the above MR merged, and then we can cherry-pick these changes in `buildout.coredev` to the other branches.