### PR TITLE
Update README-make.md to include instructions on how to run Robot Framework tests with a visible browser

### DIFF
--- a/README-make.md
+++ b/README-make.md
@@ -132,6 +132,16 @@ A few sample commands that work for me:
 .venv/bin/zope-testrunner --test-path .venv/lib/python3.12/site-packages -s plone.memoize
 ```
 
+#### Robot tests
+
+To run Robot Framework tests, you can also use `zope-testrunner`.
+If you want to see the browser in action while the tests are running, you can set the `ROBOT_BROWSER` environment variable.
+
+Example for running a specific Robot test with the Chrome browser visible:
+```bash
+ROBOT_BROWSER=chrome .venv/bin/zope-testrunner --path=src/plone.schemaeditor --all -t "Add a fieldSet and move a field into this fieldset"
+```
+
 
 ### Dirty and clean
 

--- a/README-make.md
+++ b/README-make.md
@@ -134,11 +134,11 @@ A few sample commands that work for me:
 
 #### Robot tests
 
-To run Robot Framework tests, you can also use `zope-testrunner`.
-If you want to see the browser in action while the tests are running, you can set the `ROBOT_BROWSER` environment variable.
+To watch the browser run Robot Framework tests, use `zope-testrunner` and set the `ROBOT_BROWSER` environment variable.
 
-Example for running a specific Robot test with the Chrome browser visible:
-```bash
+The following example runs a specific Robot test with the Chrome browser visible:
+
+```shell
 ROBOT_BROWSER=chrome .venv/bin/zope-testrunner --path=src/plone.schemaeditor --all -t "Add a fieldSet and move a field into this fieldset"
 ```
 


### PR DESCRIPTION
This provides a clear example using the ROBOT_BROWSER environment variable, which is helpful for developers who need to debug tests visually.