### PR TITLE
Update README-make.md to include instructions on how to run Robot Framework tests with a visible browser

### DIFF
--- a/README-make.md
+++ b/README-make.md
@@ -115,6 +115,16 @@ A few sample commands that work for me:
 .venv/bin/zope-testrunner --test-path .venv/lib/python3.12/site-packages -s plone.memoize
 ```
 
+#### Robot tests
+
+To watch the browser run Robot Framework tests, use `zope-testrunner` and set the `ROBOT_BROWSER` environment variable.
+
+The following example runs a specific Robot test with the Chrome browser visible:
+
+```shell
+ROBOT_BROWSER=chrome .venv/bin/zope-testrunner --path=src/plone.schemaeditor --all -t "Add a fieldSet and move a field into this fieldset"
+```
+
 
 ### Dirty and clean
 


### PR DESCRIPTION
Porting #1032 to 6.2