### PR TITLE
Use zc.buildout 5.0.0a1 and horse-with-no-namespace on 6.2.

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,15 +1,16 @@
 -c https://zopefoundation.github.io/Zope/releases/5.13/constraints.txt
 packaging==25.0
-pip==25.1.1
+pip==25.2
 setuptools==80.9.0
 wheel==0.45.1
-zc.buildout==4.1.12
+zc.buildout==5.0.0a1
+horse-with-no-namespace==20250705.0
 nt-svcutils==2.13.0
 five.localsitemanager==5.0
 mr.developer==2.0.3
 z3c.checkversions==3.0
 z3c.pt==5.0
-zc.recipe.egg==3.0.0
+zc.recipe.egg==4.0.0a1
 zc.recipe.testrunner==3.2
 ZODB==6.0.1
 zope.testrunner==7.4

--- a/constraints.txt
+++ b/constraints.txt
@@ -3,7 +3,7 @@ packaging==25.0
 pip==25.2
 setuptools==80.9.0
 wheel==0.45.1
-zc.buildout==5.0.0a1
+zc.buildout==5.0.0a2
 horse-with-no-namespace==20250705.0
 nt-svcutils==2.13.0
 five.localsitemanager==5.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,6 @@
 # Copied from tests.cfg
 -c constraints-all.txt
+horse-with-no-namespace
 borg.localrole
 collective.monkeypatcher
 diazo [test]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 packaging==25.0
-pip==25.1.1
+pip==25.2
 setuptools==80.9.0
 wheel==0.45.1
-zc.buildout==4.1.12
+zc.buildout==5.0.0a1
+horse-with-no-namespace==20250705.0
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ packaging==25.0
 pip==25.2
 setuptools==80.9.0
 wheel==0.45.1
-zc.buildout==5.0.0a1
+zc.buildout==5.0.0a2
 horse-with-no-namespace==20250705.0
 
 # Windows specific down here (has to be installed here, fails in buildout)

--- a/versions.cfg
+++ b/versions.cfg
@@ -17,7 +17,7 @@ packaging = 25.0
 pip = 25.2
 setuptools = 80.9.0
 wheel = 0.45.1
-zc.buildout = 5.0.0a1
+zc.buildout = 5.0.0a2
 horse-with-no-namespace = 20250705.0
 
 # windows specific

--- a/versions.cfg
+++ b/versions.cfg
@@ -14,10 +14,11 @@ extends = https://zopefoundation.github.io/Zope/releases/5.13/versions.cfg
 # Basics
 # !! keep in sync with requirements.txt !!
 packaging = 25.0
-pip = 25.1.1
+pip = 25.2
 setuptools = 80.9.0
 wheel = 0.45.1
-zc.buildout = 4.1.12
+zc.buildout = 5.0.0a1
+horse-with-no-namespace = 20250705.0
 
 # windows specific
 nt-svcutils = 2.13.0
@@ -28,7 +29,7 @@ five.localsitemanager = 5.0
 mr.developer = 2.0.3
 z3c.checkversions = 3.0
 z3c.pt = 5.0
-zc.recipe.egg = 3.0.0
+zc.recipe.egg = 4.0.0a1
 zc.recipe.testrunner = 3.2
 ZODB = 6.0.1
 zope.testrunner = 7.4


### PR DESCRIPTION
See also the notes I added in the readme on https://pypi.org/project/zc.buildout/5.0.0a1/ about native namespaces and breaking changes in 5.x.
