### PR TITLE
requirements-test.txt: add three more packages.

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -51,9 +51,12 @@ plone.base
 plone.browserlayer
 plone.cachepurging
 plone.caching
+plone.classicui[test]
 plone.contentrules
 plone.dexterity [test]
+plone.distribution[test]
 plone.event [test]
+plone.exportimport[test]
 plone.folder
 plone.formwidget.namedfile
 plone.i18n


### PR DESCRIPTION
Latest test run [failed](https://github.com/plone/buildout.coredev/actions/runs/17673021245/job/50228698148):

    ModuleNotFoundError: No module named 'plone.classicui'

Which is correct, because this package was not yet installed.

That failing test run was on the [`release/6.2-dev` branch](https://github.com/plone/buildout.coredev/tree/release/6.2-dev).  I don't know why the tests on the 6.2 branch passed.

But these three extra packages are in `tests.cfg`, which is the base for `requirements-test.txt`: I just copied the relevant lines from `tests.cfg`.
