### PR TITLE
Sources plone.base: use 3.x for Plone 6.1 due to new plone.use_ajax_m…

### DIFF
--- a/mxsources.ini
+++ b/mxsources.ini
@@ -271,7 +271,7 @@ branch = main
 [plone.base]
 url = ${settings:plone}/plone.base.git
 pushurl = ${settings:plone_push}/plone.base.git
-branch = main
+branch = 3.x
 
 [plone.batching]
 url = ${settings:plone}/plone.batching.git

--- a/sources.cfg
+++ b/sources.cfg
@@ -78,7 +78,7 @@ plone.app.workflow                  = git ${remotes:plone}/plone.app.workflow.gi
 plone.app.z3cform                   = git ${remotes:plone}/plone.app.z3cform.git pushurl=${remotes:plone_push}/plone.app.z3cform.git branch=master
 plone.autoform                      = git ${remotes:plone}/plone.autoform.git pushurl=${remotes:plone_push}/plone.autoform.git branch=master
 plone.autoinclude                   = git ${remotes:plone}/plone.autoinclude.git pushurl=${remotes:plone_push}/plone.autoinclude.git branch=main
-plone.base                          = git ${remotes:plone}/plone.base.git pushurl=${remotes:plone_push}/plone.base.git branch=main
+plone.base                          = git ${remotes:plone}/plone.base.git pushurl=${remotes:plone_push}/plone.base.git branch=3.x
 plone.batching                      = git ${remotes:plone}/plone.batching.git pushurl=${remotes:plone_push}/plone.batching.git branch=master
 plone.behavior                      = git ${remotes:plone}/plone.behavior.git pushurl=${remotes:plone_push}/plone.behavior.git branch=master
 plone.browserlayer                  = git ${remotes:plone}/plone.browserlayer.git pushurl=${remotes:plone_push}/plone.browserlayer.git branch=master


### PR DESCRIPTION
…ain_template setting, which is only available in Plone 6.2 and up.

If we merge https://github.com/plone/plone.base/pull/87 the new setting will break the site controlpanel if no upgrade step is run. Also, the setting doesn't make sense in Plone 6.1 as it lacks the implementation in cmfplone and plone.app.layout.


## Related PRs

https://github.com/plone/Products.CMFPlone/pull/4169
https://github.com/plone/plone.app.layout/pull/405
https://github.com/plone/plone.base/pull/87
https://github.com/plone/plone.app.theming/pull/265
https://github.com/plone/plone.app.upgrade/pull/345
https://github.com/plone/buildout.coredev/pull/1036
https://github.com/plone/buildout.coredev/pull/1037
