### PR TITLE
Use latest pip, setuptools, zc.buildout on 6.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-packaging==24.2
-pip==25.0.1
-setuptools==75.8.2
+packaging==25.0
+pip==25.2
+setuptools==80.9.0
 wheel==0.45.1
-zc.buildout==4.1.4
+zc.buildout==4.1.12
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -13,16 +13,17 @@ extends = https://zopefoundation.github.io/Zope/releases/5.13/versions.cfg
 [versions]
 # Basics
 # !! keep in sync with requirements.txt !!
-packaging = 24.2
-pip = 25.0.1
-setuptools = 75.8.2
+packaging = 25.0
+pip = 25.2
+setuptools = 80.9.0
 wheel = 0.45.1
-zc.buildout = 4.1.4
+zc.buildout = 4.1.12
 
 # windows specific
 nt-svcutils = 2.13.0
 
 # OVERRIDES
+mr.developer = 2.0.3
 
 # CORE PLONE.
 # These packages are what you get when installing Plone plus test dependencies,


### PR DESCRIPTION
Well, the latest final releases.  I don't want a zc.buildout alpha release here.

