### PR TITLE
Remove xmltestreport, alltests, and precompiler [6.2.]

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -124,7 +124,6 @@ collective.MockMailHost==3.0.0
 collective.monkeypatcher==2.0.1
 collective.recipe.omelette==2.0.0
 collective.recipe.vscode==0.1.9
-collective.xmltestreport==2.0.2
 icalendar==6.3.1
 Products.DateRecurringIndex==3.0.1
 robotsuite==2.3.2

--- a/mxsources.ini
+++ b/mxsources.ini
@@ -33,11 +33,6 @@ url = ${settings:collective}/collective.recipe.omelette.git
 pushurl = ${settings:collective_push}/collective.recipe.omelette.git
 branch = master
 
-[collective.xmltestreport]
-url = ${settings:collective}/collective.xmltestreport.git
-pushurl = ${settings:collective_push}/collective.xmltestreport.git
-branch = master
-
 [diazo]
 url = ${settings:plone}/diazo.git
 pushurl = ${settings:plone_push}/diazo.git
@@ -401,16 +396,6 @@ branch = master
 [plone.protect]
 url = ${settings:plone}/plone.protect.git
 pushurl = ${settings:plone_push}/plone.protect.git
-branch = master
-
-[plone.recipe.alltests]
-url = ${settings:plone}/plone.recipe.alltests.git
-pushurl = ${settings:plone_push}/plone.recipe.alltests.git
-branch = master
-
-[plone.recipe.precompiler]
-url = ${settings:plone}/plone.recipe.precompiler.git
-pushurl = ${settings:plone_push}/plone.recipe.precompiler.git
 branch = master
 
 [plone.recipe.zeoserver]

--- a/sources.cfg
+++ b/sources.cfg
@@ -31,7 +31,6 @@ plone.themepreview                  = git ${remotes:plone}/plone.themepreview.gi
 borg.localrole                      = git ${remotes:plone}/borg.localrole.git pushurl=${remotes:plone_push}/borg.localrole.git branch=master
 collective.monkeypatcher            = git ${remotes:plone}/collective.monkeypatcher.git pushurl=${remotes:plone_push}/collective.monkeypatcher.git branch=master
 collective.recipe.omelette          = git ${remotes:collective}/collective.recipe.omelette.git pushurl=${remotes:collective_push}/collective.recipe.omelette.git branch=master
-collective.xmltestreport            = git ${remotes:collective}/collective.xmltestreport.git pushurl=${remotes:collective_push}/collective.xmltestreport.git branch=master
 diazo                               = git ${remotes:plone}/diazo.git pushurl=${remotes:plone_push}/diazo.git branch=master
 five.customerize                    = git ${remotes:zope}/five.customerize.git pushurl=${remotes:zope_push}/five.customerize.git branch=master
 five.intid                          = git ${remotes:plone}/five.intid.git pushurl=${remotes:plone_push}/five.intid.git branch=master
@@ -105,8 +104,6 @@ plone.portlet.collection            = git ${remotes:plone}/plone.portlet.collect
 plone.portlet.static                = git ${remotes:plone}/plone.portlet.static.git pushurl=${remotes:plone_push}/plone.portlet.static.git branch=master
 plone.portlets                      = git ${remotes:plone}/plone.portlets.git pushurl=${remotes:plone_push}/plone.portlets.git branch=master
 plone.protect                       = git ${remotes:plone}/plone.protect.git pushurl=${remotes:plone_push}/plone.protect.git branch=master
-plone.recipe.alltests               = git ${remotes:plone}/plone.recipe.alltests.git pushurl=${remotes:plone_push}/plone.recipe.alltests.git branch=master
-plone.recipe.precompiler            = git ${remotes:plone}/plone.recipe.precompiler.git pushurl=${remotes:plone_push}/plone.recipe.precompiler.git branch=master
 plone.recipe.zeoserver              = git ${remotes:plone}/plone.recipe.zeoserver.git pushurl=${remotes:plone_push}/plone.recipe.zeoserver.git branch=master
 plone.recipe.zope2instance          = git ${remotes:plone}/plone.recipe.zope2instance.git pushurl=${remotes:plone_push}/plone.recipe.zope2instance.git branch=master
 plone.registry                      = git ${remotes:plone}/plone.registry.git pushurl=${remotes:plone_push}/plone.registry.git branch=master
@@ -165,9 +162,3 @@ z3c.relationfield                   = git ${remotes:zope}/z3c.relationfield.git 
 zodbupdate                          = git ${remotes:zope}/zodbupdate.git pushurl=${remotes:zope_push}/zodbupdate.git branch=master
 zodbverify                          = git ${remotes:plone}/zodbverify.git pushurl=${remotes:plone_push}/zodbverify.git branch=master
 Zope                                = git ${remotes:zope}/Zope.git pushurl=${remotes:zope_push}/Zope.git branch=master
-
-
-[precompiler]
-recipe = plone.recipe.precompiler
-eggs = ${instance:eggs}
-compile-mo-files = true

--- a/versions.cfg
+++ b/versions.cfg
@@ -151,7 +151,6 @@ collective.MockMailHost = 3.0.0
 collective.monkeypatcher = 2.0.1
 collective.recipe.omelette = 2.0.0
 collective.recipe.vscode = 0.1.9
-collective.xmltestreport = 2.0.2
 icalendar = 6.3.1
 Products.DateRecurringIndex = 3.0.1
 robotsuite = 2.3.2


### PR DESCRIPTION
This removes `collective.xmltestreport`, `plone.recipe.alltests`, and `plone.recipe.precompiler` from sources and versions. None of these are used anymore on 6.2.

