### PR TITLE
Use latest horse-with-no-namespace 20251105.1

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -4,7 +4,7 @@ pip==25.2
 setuptools==80.9.0
 wheel==0.45.1
 zc.buildout==5.0.0a3
-horse-with-no-namespace==20250705.0
+horse-with-no-namespace==20251105.1
 nt-svcutils==2.13.0
 five.localsitemanager==5.0
 mr.developer==2.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pip==25.2
 setuptools==80.9.0
 wheel==0.45.1
 zc.buildout==5.0.0a3
-horse-with-no-namespace==20250705.0
+horse-with-no-namespace==20251105.1
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -18,7 +18,7 @@ pip = 25.2
 setuptools = 80.9.0
 wheel = 0.45.1
 zc.buildout = 5.0.0a3
-horse-with-no-namespace = 20250705.0
+horse-with-no-namespace = 20251105.1
 
 # windows specific
 nt-svcutils = 2.13.0


### PR DESCRIPTION
Works locally.