### PR TITLE
Update Products.ZCatalog 7.2.1, use plone.app.querystring fix.

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -9,6 +9,7 @@ auto-checkout =
     plone.app.upgrade
     Products.CMFPlone
 # These packages are manually added, or automatically added by mr.roboto:
+    plone.app.querystring
     plone.restapi
     plonetheme.barceloneta
     plone.scale

--- a/constraints.txt
+++ b/constraints.txt
@@ -14,6 +14,7 @@ zc.recipe.egg==4.0.0a1
 zc.recipe.testrunner==3.2
 ZODB==6.0.1
 zope.testrunner==7.4
+Products.ZCatalog==7.2.1
 borg.localrole==3.1.11
 diazo==2.0.3
 five.intid==3.0.2

--- a/mx.ini
+++ b/mx.ini
@@ -27,6 +27,7 @@ version-overrides =
     zc.recipe.testrunner==3.2
     ZODB==6.0.1
     zope.testrunner==7.4
+    Products.ZCatalog==7.2.1
 
 # mxmake related mxdev extensions
 mxmake-test-runner = zope-testrunner

--- a/mxcheckouts.ini
+++ b/mxcheckouts.ini
@@ -16,6 +16,9 @@ use = true
 [Products.CMFPlone]
 use = true
 
+[plone.app.querystring]
+use = true
+
 [plone.restapi]
 use = true
 

--- a/mxsources.ini
+++ b/mxsources.ini
@@ -171,7 +171,7 @@ branch = master
 [plone.app.querystring]
 url = ${settings:plone}/plone.app.querystring.git
 pushurl = ${settings:plone_push}/plone.app.querystring.git
-branch = master
+branch = maurits-tests-newer-zcatalog
 
 [plone.app.redirector]
 url = ${settings:plone}/plone.app.redirector.git

--- a/sources.cfg
+++ b/sources.cfg
@@ -58,7 +58,7 @@ plone.app.locales                   = git ${remotes:collective}/plone.app.locale
 plone.app.lockingbehavior           = git ${remotes:plone}/plone.app.lockingbehavior.git pushurl=${remotes:plone_push}/plone.app.lockingbehavior.git branch=master
 plone.app.multilingual              = git ${remotes:plone}/plone.app.multilingual.git pushurl=${remotes:plone_push}/plone.app.multilingual.git branch=master
 plone.app.portlets                  = git ${remotes:plone}/plone.app.portlets.git pushurl=${remotes:plone_push}/plone.app.portlets.git branch=master
-plone.app.querystring               = git ${remotes:plone}/plone.app.querystring.git pushurl=${remotes:plone_push}/plone.app.querystring.git branch=master
+plone.app.querystring               = git ${remotes:plone}/plone.app.querystring.git pushurl=${remotes:plone_push}/plone.app.querystring.git branch=maurits-tests-newer-zcatalog
 plone.app.redirector                = git ${remotes:plone}/plone.app.redirector.git pushurl=${remotes:plone_push}/plone.app.redirector.git branch=master
 plone.app.registry                  = git ${remotes:plone}/plone.app.registry.git pushurl=${remotes:plone_push}/plone.app.registry.git branch=master
 plone.app.relationfield             = git ${remotes:plone}/plone.app.relationfield.git pushurl=${remotes:plone_push}/plone.app.relationfield.git branch=master

--- a/versions.cfg
+++ b/versions.cfg
@@ -33,6 +33,7 @@ zc.recipe.egg = 4.0.0a1
 zc.recipe.testrunner = 3.2
 ZODB = 6.0.1
 zope.testrunner = 7.4
+Products.ZCatalog = 7.2.1
 
 # CORE PLONE.
 # These packages are what you get when installing Plone plus test dependencies,


### PR DESCRIPTION
This uses the branch from https://github.com/plone/plone.app.querystring/pull/171.  See explanation there.

I will mark this as draft PR.  After approval, I can update just the pin, so we don't change the `plone.app.querystring` branch, which will be gone after we have merged that PR.