### PR TITLE
Use zc.buildout 5.1.0

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,16 +1,16 @@
 -c https://zopefoundation.github.io/Zope/releases/5.13/constraints.txt
+horse-with-no-namespace==20251105.1
 packaging==25.0
-pip==25.2
+pip==25.3
 setuptools==80.9.0
 wheel==0.45.1
-zc.buildout==5.0.0a3
-horse-with-no-namespace==20251105.1
+zc.buildout==5.1.0
 nt-svcutils==2.13.0
 five.localsitemanager==5.0
-mr.developer==2.0.3
+mr.developer==2.0.4
 z3c.checkversions==3.0
 z3c.pt==5.0
-zc.recipe.egg==4.0.0a1
+zc.recipe.egg==4.0.0
 zc.recipe.testrunner==3.2
 ZODB==6.0.1
 zope.testrunner==7.4

--- a/mx.ini
+++ b/mx.ini
@@ -19,11 +19,11 @@ version-overrides =
 # You MUST manually keep this in sync with the OVERRIDES in versions.cfg
 # plus the packaging pin above it.
     five.localsitemanager==5.0
-    mr.developer==2.0.3
+    mr.developer==2.0.4
     packaging==25.0
     z3c.checkversions==3.0
     z3c.pt==5.0
-    zc.recipe.egg==4.0.0a1
+    zc.recipe.egg==4.0.0
     zc.recipe.testrunner==3.2
     ZODB==6.0.1
     zope.testrunner==7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
+horse-with-no-namespace==20251105.1
 packaging==25.0
-pip==25.2
+pip==25.3
 setuptools==80.9.0
 wheel==0.45.1
-zc.buildout==5.0.0a3
-horse-with-no-namespace==20251105.1
+zc.buildout==5.1.0
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/versions.cfg
+++ b/versions.cfg
@@ -13,12 +13,12 @@ extends = https://zopefoundation.github.io/Zope/releases/5.13/versions.cfg
 [versions]
 # Basics
 # !! keep in sync with requirements.txt !!
+horse-with-no-namespace = 20251105.1
 packaging = 25.0
-pip = 25.2
+pip = 25.3
 setuptools = 80.9.0
 wheel = 0.45.1
-zc.buildout = 5.0.0a3
-horse-with-no-namespace = 20251105.1
+zc.buildout = 5.1.0
 
 # windows specific
 nt-svcutils = 2.13.0
@@ -26,10 +26,10 @@ nt-svcutils = 2.13.0
 # OVERRIDES
 # You MUST manually keep this in sync with the version-overrides in mx.ini.
 five.localsitemanager = 5.0
-mr.developer = 2.0.3
+mr.developer = 2.0.4
 z3c.checkversions = 3.0
 z3c.pt = 5.0
-zc.recipe.egg = 4.0.0a1
+zc.recipe.egg = 4.0.0
 zc.recipe.testrunner = 3.2
 ZODB = 6.0.1
 zope.testrunner = 7.4


### PR DESCRIPTION
And update `pip`, `mr.developer`, and `zc.recipe.egg`.

Buildout now prints a warning at the end:

```
** WARNING **
Some development packages are using old style namespace packages.
You should switch to native namespaces (PEP 420).
If you get a ModuleNotFound or an ImportError when importing a package
from one of these namespaces, you can try this as a temporary workaround:

    pip install horse-with-no-namespace

Note: installing horse-with-no-namespace with buildout will not work.
You must install it into the virtualenv with pip (or uv) before running the buildout.

The following list shows the affected packages and their namespaces:

* plone.restapi: plone
* plone.volto: plone
```

