### PR TITLE
Use Zope 6.0b1 and its versions. [6.2]

### DIFF
--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -9,7 +9,6 @@ auto-checkout =
     plone.app.upgrade
     Products.CMFPlone
 # These packages are manually added, or automatically added by mr.roboto:
-    Zope
     plone.restapi
     plonetheme.barceloneta
     plone.scale

--- a/checkouts.cfg
+++ b/checkouts.cfg
@@ -9,6 +9,7 @@ auto-checkout =
     plone.app.upgrade
     Products.CMFPlone
 # These packages are manually added, or automatically added by mr.roboto:
+    Zope
     plone.restapi
     plonetheme.barceloneta
     plone.scale

--- a/constraints-extra.txt
+++ b/constraints-extra.txt
@@ -38,8 +38,11 @@ stdlib-list==0.11.1
 wadllib==2.0.0
 webencodings==0.5.1
 wmctrl==0.5
+z3c.checkversions==3.0
 z3c.dependencychecker==2.15
 zest.pocompile==2.0.0
 zodbverify==1.2.0
 zope.mkzeoinstance==6.0
 ZopeUndo==6.0
+tomli==2.3.0; python_version > "3.10"
+tomli==2.2.1; python_version == "3.10"

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,4 @@
--c https://zopefoundation.github.io/Zope/releases/5.13/constraints.txt
+-c https://raw.githubusercontent.com/zopefoundation/Zope/master/constraints.txt
 horse-with-no-namespace==20251105.1
 packaging==25.0
 pip==25.3
@@ -6,15 +6,6 @@ setuptools==80.9.0
 wheel==0.45.1
 zc.buildout==5.1.0
 nt-svcutils==2.13.0
-five.localsitemanager==5.0
-mr.developer==2.0.4
-z3c.checkversions==3.0
-z3c.pt==5.0
-zc.recipe.egg==4.0.0
-zc.recipe.testrunner==3.2
-ZODB==6.0.1
-zope.testrunner==7.4
-Products.ZCatalog==7.2.1
 borg.localrole==3.1.11
 diazo==2.0.3
 five.intid==3.0.2
@@ -183,6 +174,7 @@ future==1.0.0
 gunicorn==23.0.0
 h11==0.16.0
 id==1.5.0
+importlib-metadata==8.7.0
 importlib-resources==6.5.2
 iniconfig==2.1.0
 jaraco.classes==3.4.0
@@ -256,7 +248,6 @@ trove-classifiers==2025.5.9.12
 twine==6.1.0
 types-PyYAML==6.0.12.10
 types-toml==0.10.8.5
-typing-extensions==4.14.0
 tzdata==2025.2
 Unidecode==1.4.0
 urllib3-secure-extra==0.1.0
@@ -265,4 +256,5 @@ wcwidth==0.2.13
 webresource==1.2
 wrapt==1.17.2
 wsproto==1.2.0
+zipp==3.23.0
 pywin32-ctypes==0.2.3; platform_system == "Windows"

--- a/mx.ini
+++ b/mx.ini
@@ -17,17 +17,6 @@ include =
     mxtests.ini
 version-overrides =
 # You MUST manually keep this in sync with the OVERRIDES in versions.cfg
-# plus the packaging pin above it.
-    five.localsitemanager==5.0
-    mr.developer==2.0.4
-    packaging==25.0
-    z3c.checkversions==3.0
-    z3c.pt==5.0
-    zc.recipe.egg==4.0.0
-    zc.recipe.testrunner==3.2
-    ZODB==6.0.1
-    zope.testrunner==7.4
-    Products.ZCatalog==7.2.1
 
 # mxmake related mxdev extensions
 mxmake-test-runner = zope-testrunner

--- a/mxcheckouts.ini
+++ b/mxcheckouts.ini
@@ -16,6 +16,9 @@ use = true
 [Products.CMFPlone]
 use = true
 
+[Zope]
+use = true
+
 [plone.restapi]
 use = true
 

--- a/versions-extra.cfg
+++ b/versions-extra.cfg
@@ -43,11 +43,18 @@ stdlib-list = 0.11.1
 wadllib = 2.0.0
 webencodings = 0.5.1
 wmctrl = 0.5
+z3c.checkversions = 3.0
 z3c.dependencychecker = 2.15
 zest.pocompile = 2.0.0
 zodbverify = 1.2.0
 zope.mkzeoinstance = 6.0
 ZopeUndo = 6.0
+
+[versions:python_version > "3.10"]
+tomli = 2.3.0
+
+[versions:python_version == "3.10"]
+tomli = 2.2.1
 
 [versionannotations]
 # keep this alphabetical please

--- a/versions.cfg
+++ b/versions.cfg
@@ -5,9 +5,9 @@
 # Note: version pins in this file should only be removed in a new minor version of Plone.
 
 # Based on latest development Zope:
-# extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
+extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
 # Based on released Zope:
-extends = https://zopefoundation.github.io/Zope/releases/5.13/versions.cfg
+# extends = https://zopefoundation.github.io/Zope/releases/5.13/versions.cfg
 
 
 [versions]
@@ -25,15 +25,6 @@ nt-svcutils = 2.13.0
 
 # OVERRIDES
 # You MUST manually keep this in sync with the version-overrides in mx.ini.
-five.localsitemanager = 5.0
-mr.developer = 2.0.4
-z3c.checkversions = 3.0
-z3c.pt = 5.0
-zc.recipe.egg = 4.0.0
-zc.recipe.testrunner = 3.2
-ZODB = 6.0.1
-zope.testrunner = 7.4
-Products.ZCatalog = 7.2.1
 
 # CORE PLONE.
 # These packages are what you get when installing Plone plus test dependencies,
@@ -219,6 +210,7 @@ future = 1.0.0
 gunicorn = 23.0.0
 h11 = 0.16.0
 id = 1.5.0
+importlib-metadata = 8.7.0
 importlib-resources = 6.5.2
 iniconfig = 2.1.0
 jaraco.classes = 3.4.0
@@ -293,7 +285,6 @@ trove-classifiers = 2025.5.9.12
 twine = 6.1.0
 types-PyYAML = 6.0.12.10
 types-toml = 0.10.8.5
-typing-extensions = 4.14.0
 tzdata = 2025.2
 Unidecode = 1.4.0
 urllib3-secure-extra = 0.1.0
@@ -302,6 +293,7 @@ wcwidth = 0.2.13
 webresource = 1.2
 wrapt = 1.17.2
 wsproto = 1.2.0
+zipp = 3.23.0
 
 [versions:windows]
 pywin32-ctypes = 0.2.3

--- a/versions.cfg
+++ b/versions.cfg
@@ -5,9 +5,9 @@
 # Note: version pins in this file should only be removed in a new minor version of Plone.
 
 # Based on latest development Zope:
-extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
+# extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
 # Based on released Zope:
-# extends = https://zopefoundation.github.io/Zope/releases/5.13/versions.cfg
+extends = https://zopefoundation.github.io/Zope/releases/6.0b1/versions.cfg
 
 
 [versions]


### PR DESCRIPTION
This has lots more native namespace packages, and is very close to Python 3.14 support.
