### PR TITLE
Remove `plone.app.widgets` from `tests.cfg`

### DIFF
--- a/tests.cfg
+++ b/tests.cfg
@@ -44,7 +44,6 @@ test-eggs =
     plone.app.versioningbehavior [tests]
     plone.app.viewletmanager
     plone.app.vocabularies
-    plone.app.widgets [test]
     plone.app.workflow
     plone.app.z3cform [test]
     plone.autoform


### PR DESCRIPTION
Since there is no more code needed from `plone.app.widgets` in the core...