### PR TITLE
GHA: upgrade to macos-14.

### DIFF
--- a/.github/workflows/run-buildout.yml
+++ b/.github/workflows/run-buildout.yml
@@ -15,7 +15,7 @@ jobs:
         os:
         - ubuntu-latest
         - windows-latest
-        - macos-13
+        - macos-14
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The macOS-13 based runner images are now retired.
See for example https://github.com/plone/buildout.coredev/actions/runs/20064685548/job/57550041497
