### PR TITLE
Define sources for all ecosystem packages.

### DIFF
--- a/ecosystem.cfg
+++ b/ecosystem.cfg
@@ -12,8 +12,9 @@ custom-eggs +=
 #    collective.z3cform.datetimewidget
     plone.app.debugtoolbar
     plone.app.mosaic
-# Not Zope 5 compatible:
+# Still uses Products.PloneTestCase for tests:
 #    plone.formwidget.autocomplete
+# Not Zope 5 compatible:
 #    plone.formwidget.contenttree
 # Still has Archetypes code, and requires unittest2:
 #    plone.formwidget.datetime
@@ -30,7 +31,18 @@ test-eggs =
     plone.app.mosaic[test]
 
 [sources]
-plone.app.mosaic                    = git ${remotes:plone}/plone.app.mosaic.git pushurl=${remotes:plone_push}/plone.app.mosaic.git branch=master
 collective.z3cform.datagridfield    = git ${remotes:collective}/collective.z3cform.datagridfield.git pushurl=${remotes:collective_push}/collective.z3cform.datagridfield.git branch=master
+plone.app.blocks                    = git ${remotes:plone}/plone.app.blocks.git pushurl=${remotes:plone_push}/plone.app.blocks.git branch=master
 plone.app.debugtoolbar              = git ${remotes:plone}/plone.app.debugtoolbar.git pushurl=${remotes:plone_push}/plone.app.debugtoolbar.git branch=master
+plone.app.drafts                    = git ${remotes:plone}/plone.app.drafts.git pushurl=${remotes:plone_push}/plone.app.drafts.git branch=master
+plone.app.jquerytools               = git ${remotes:plone}/plone.app.jquerytools.git pushurl=${remotes:plone_push}/plone.app.jquerytools.git branch=master
+plone.app.mosaic                    = git ${remotes:plone}/plone.app.mosaic.git pushurl=${remotes:plone_push}/plone.app.mosaic.git branch=master
+plone.app.standardtiles             = git ${remotes:plone}/plone.app.standardtiles.git pushurl=${remotes:plone_push}/plone.app.standardtiles.git branch=main
+plone.app.tiles                     = git ${remotes:plone}/plone.app.tiles.git pushurl=${remotes:plone_push}/plone.app.tiles.git branch=master
+plone.formwidget.autocomplete       = git ${remotes:plone}/plone.formwidget.autocomplete.git pushurl=${remotes:plone_push}/plone.formwidget.autocomplete.git branch=master
+plone.jsonserializer                = git ${remotes:plone}/plone.jsonserializer.git pushurl=${remotes:plone_push}/plone.jsonserializer.git branch=master
 Products.PDBDebugMode               = git ${remotes:collective}/Products.PDBDebugMode.git pushurl=${remotes:collective_push}/Products.PDBDebugMode.git branch=master
+Products.PrintingMailHost           = git ${remotes:collective}/Products.PrintingMailHost.git pushurl=${remotes:collective_push}/Products.PrintingMailHost.git branch=master
+Products.validation                 = git ${remotes:plone}/Products.validation.git pushurl=${remotes:plone_push}/Products.validation.git branch=main
+z3c.jbot                            = git ${remotes:zope}/z3c.jbot.git pushurl=${remotes:zope_push}/z3c.jbot.git branch=master
+z3c.unconfigure                     = git ${remotes:zope}/z3c.unconfigure.git pushurl=${remotes:zope_push}/z3c.unconfigure.git branch=master

--- a/versions-ecosystem.cfg
+++ b/versions-ecosystem.cfg
@@ -18,5 +18,5 @@ plone.formwidget.autocomplete = 1.5.0
 plone.jsonserializer = 0.9.11
 Products.PDBDebugMode = 2.1
 Products.PrintingMailHost = 1.1.8
-Products.validation = 3.0.0
+Products.validation = 3.0.1
 z3c.jbot = 3.1


### PR DESCRIPTION
At least for the ones that we have in `custom-eggs`.

Initially I added `plone.formwidget.autocomplete` to the custom eggs.  It was commented out until now, but we *do* have it in `versions-ecosystem.cfg`. But then I commented it out again because its tests utterly fail: it needs `Products.PloneTestCase`.

These packages remain commented out in both `ecosystem.cfg` and `versions-ecosystem.cfg`:

```
collective.z3cform.datetimewidget
plone.formwidget.autocomplete
plone.formwidget.contenttree
plone.formwidget.datetime
```

Note that all or most ecosystem packages still need to be moved to native namespaces, which is why I am adding them here.
