### PR TITLE
Use Zope 6.0b2

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,4 @@
--c https://zopefoundation.github.io/Zope/releases/6.0b1/constraints.txt
+-c https://zopefoundation.github.io/Zope/releases/6.0b2/constraints.txt
 horse-with-no-namespace==20251105.1
 packaging==25.0
 pip==25.3
@@ -6,8 +6,6 @@ setuptools==80.9.0
 wheel==0.45.1
 zc.buildout==5.1.1
 nt-svcutils==2.13.0
-plone.versioncheck==2.0.1
-Products.ZCatalog==7.3
 borg.localrole==5.0.0a1
 diazo==2.0.4
 five.intid==3.0.2

--- a/mx.ini
+++ b/mx.ini
@@ -17,8 +17,6 @@ include =
     mxtests.ini
 version-overrides =
 # You MUST manually keep this in sync with the OVERRIDES in versions.cfg
-    plone.versioncheck==2.0.1
-    Products.ZCatalog==7.3
 
 # mxmake related mxdev extensions
 mxmake-test-runner = zope-testrunner

--- a/versions.cfg
+++ b/versions.cfg
@@ -7,7 +7,7 @@
 # Based on latest development Zope:
 # extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
 # Based on released Zope:
-extends = https://zopefoundation.github.io/Zope/releases/6.0b1/versions.cfg
+extends = https://zopefoundation.github.io/Zope/releases/6.0b2/versions.cfg
 
 
 [versions]
@@ -25,8 +25,6 @@ nt-svcutils = 2.13.0
 
 # OVERRIDES
 # You MUST manually keep this in sync with the version-overrides in mx.ini.
-plone.versioncheck = 2.0.1
-Products.ZCatalog = 7.3
 
 # CORE PLONE.
 # These packages are what you get when installing Plone plus test dependencies,


### PR DESCRIPTION
Zope 6.0b2 was released today.

This fixes a blocker for our first 6.2 alpha release: https://github.com/plone/buildout.coredev/issues/1065

@stevepiercy The new Zope versions/constraints include an update to Sphinx, best seen in the new constraints.txt from Zope:

```
Sphinx==8.1.3; python_version == '3.10'
Sphinx==9.0.4; python_version == '3.11'
Sphinx==9.1.0; python_version > '3.11'
```

So if we run into problems generating docs in any project, this could be the reason.  But that would only surface after I update https://dist.plone.org/release/6.2-dev/
