### PR TITLE
Add workflow to run full test suite on GHA.

### DIFF
--- a/.github/workflows/full-shared.yml
+++ b/.github/workflows/full-shared.yml
@@ -1,0 +1,59 @@
+name: "Shared setup for running full tests"
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        required: false
+        type: string
+        default: "3.14"
+      prepare-command:
+        required: false
+        type: string
+        default: ""
+      test-command:
+        required: false
+        type: string
+        default: "make test"
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    env:
+        PYTHONWARNINGS: ignore
+        GIT_CLONE_DEPTH: 1
+        CHAMELEON_CACHE: 'chameleon_cache'
+        zope_i18n_compile_mo_files: 'true'
+        ROBOTSUITE_LOGLEVEL: ERROR
+        ROBOTSUITE_PREFIX: ONLYROBOT
+    steps:
+    - name: OS packages
+      run:
+        sudo apt-get update && sudo apt-get install -y wv poppler-utils pdftohtml gettext
+    - name: locale
+      # needed for CMFPlone testUnicodeSplitter test on Ubuntu
+      run: |
+        sudo locale-gen nl_NL@euro
+        sudo update-locale
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ inputs.python-version}}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version}}
+        cache: 'pip'
+    - name: Create Chameleon cache dir
+      run: |
+        mkdir -p "${CHAMELEON_CACHE}"
+    - name: Install
+      # Run 'make install' twice. Usually the second run still does something.
+      run: |
+        make install
+        make install
+    - name: Prepare
+      if: ${{ inputs.prepare-command }}
+      run: |
+        ${{ inputs.prepare-command }}
+    - name: Test
+      run: |
+        ${{ inputs.test-command }}

--- a/.github/workflows/run-full-test.yml
+++ b/.github/workflows/run-full-test.yml
@@ -1,5 +1,10 @@
 name: Run full test suite
-on: push
+on:
+  push:
+    branches:
+      - "6.2"
+  pull_request:
+  workflow_dispatch:
 jobs:
   testfunctional:
     name: ${{ matrix.python-version }} ${{ matrix.module }} functional

--- a/.github/workflows/run-full-test.yml
+++ b/.github/workflows/run-full-test.yml
@@ -1,0 +1,39 @@
+name: Run full test suite
+on: push
+jobs:
+  testfunctional:
+    name: ${{ matrix.python-version }} ${{ matrix.module }} functional
+    strategy:
+      matrix:
+        python-version:
+        - "3.13"
+        - "3.14"
+        module:
+        - Products.CMFPlone
+        - plone.app
+        - "!Products -m !plone.app"
+    uses: ./.github/workflows/full-shared.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      # Note: the ubuntu-latest runners have 4 cpus, so we could run tests in
+      # parallel by adding '-j 4' to the TEST_ARGS.  But this can lead to a
+      # strange error in zope.i18n.zcml.registerTranslations:
+      # struct.error: unpack requires a buffer of 4 bytes
+      test-command: make test TEST_ARGS='-f -m ${{ matrix.module }}'
+
+  testrobot:
+    name: ${{ matrix.python-version }} ${{ matrix.module }} robots
+    strategy:
+      matrix:
+        python-version:
+        - "3.13"
+        - "3.14"
+        module:
+        - Products.CMFPlone
+        - "!Products.CMFPlone"
+    uses: ./.github/workflows/full-shared.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      prepare-command: make rfbrowser
+      # Note: robot tests should not be run in parallel.
+      test-command: make test TEST_ARGS='-t ONLYROBOT --all -m ${{ matrix.module}}'

--- a/.github/workflows/run-full-test.yml
+++ b/.github/workflows/run-full-test.yml
@@ -14,7 +14,7 @@ jobs:
         - "3.13"
         - "3.14"
         module:
-        - Products.CMFPlone
+        - Products
         - plone.app
         - "!Products -m !plone.app"
     uses: ./.github/workflows/full-shared.yml

--- a/README-make.md
+++ b/README-make.md
@@ -107,22 +107,97 @@ Run `make zope-start` to start the Zope instance.
 
 ### Run tests
 
-This is not in the Makefile yet.  We need to figure out how best to run the tests first.
-A few sample commands that work for me:
+Use the `make test` target to run tests for one or more packages.
+Without extra arguments, this runs all tests (except robot tests) for all packages that we want to test in core.
 
+```shell
+make test
 ```
-.venv/bin/zope-testrunner --test-path src/Products.CMFPlone/src -u
-.venv/bin/zope-testrunner --test-path .venv/lib/python3.12/site-packages -s plone.memoize
+
+To influence what tests are run, you can use `TEST_ARGS` and/or `TEST_PACKAGE`.
+You can pass these on the command line or set them as an environment variable.
+
+Run all unit and functional tests for a given package:
+
+```shell
+make test TEST_PACKAGE=plone.namedfile
 ```
+
+Alternatively:
+
+```shell
+export TEST_PACKAGE=plone.namedfile
+make test
+```
+
+Under the hood this calls `zope-testrunner`.
+To find out which arguments this supports, ask for help:
+
+```shell
+make test TEST_ARGS=--help
+```
+
+Run all pure unit tests (so no test layers) for all packages:
+
+```shell
+make test TEST_ARGS=-u
+```
+
+Enter an interactive prompt after the first test failure:
+
+```shell
+make test TEST_ARGS=-D
+```
+
+List all tests for a given package
+
+```shell
+make test TEST_ARGS=--list-tests TEST_PACKAGE=plone.namedfile
+```
+
+Run tests for multiple packages:
+
+```shell
+make test TEST_ARGS='-m plone.namedfile -m plone.scale'
+```
+
+Note: using `-s` instead of `-m` in the previous example won't work.
+`make test` calls a command that already passes about 100 packages with `-s`, unless you override it with `TEST_PACKAGE`.
+
 
 #### Robot tests
 
-To watch the browser run Robot Framework tests, use `zope-testrunner` and set the `ROBOT_BROWSER` environment variable.
+To run robot tests, you must do two things.
+First you must install or sync the robotframework browser packages, which is done with NodeJS:
+
+```shell
+make rfbrowser
+```
+
+You need to do this only once per testing session:
+you can make multiple `make test` calls with robot tests after this.
+
+Second: pass the `--all` argument.
+Otherwise robot tests are skipped.
+
+Run all pure unit, functional, and robot tests for a package:
+
+```shell
+make test TEST_ARGS=--all TEST_PACKAGE=Products.CMFPlone
+```
+
+Run only the robot tests for a package:
+
+```shell
+make test TEST_ARGS='-t ONLYROBOT --all' TEST_PACKAGE=Products.CMFPlone
+```
+
+To watch the browser run Robot Framework tests, set the `ROBOT_BROWSER` environment variable.
 
 The following example runs a specific Robot test with the Chrome browser visible:
 
 ```shell
-ROBOT_BROWSER=chrome .venv/bin/zope-testrunner --path=src/plone.schemaeditor --all -t "Add a fieldSet and move a field into this fieldset"
+ROBOT_BROWSER=chrome make test TEST_PACKAGE=plone.schemaeditor TEST_ARGS='--all -t "Add a fieldSet and move a field into this fieldset"'
 ```
 
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -163,6 +163,10 @@ fi
 # Note: the --auto-path requires zope.testrunner 7.4 or higher.
 CMD="zope-testrunner --auto-color --auto-progress --auto-path $TEST_ARGS"
 echo "Running $CMD"
-$CMD
+
+# In most cases we can call $CMD directly.
+# But when you have quotes within quotes, 'eval' helps.  For example:
+# make test TEST_ARGS='--all -t "Add a fieldSet and move a field into this fieldset"'
+eval $CMD
 
 exit 0


### PR DESCRIPTION
This is a continuation from [PR 1071](https://github.com/plone/buildout.coredev/pull/1071). Especially see [this comment](https://github.com/plone/buildout.coredev/pull/1071#issuecomment-3926570133) on what did not yet work at that time.

As a start, we use Python 3.13.  Later we can move this to 3.14.  Then we have this as long as 3.14 does not work on Jenkins. For Jenkins, see https://github.com/plone/jenkins.plone.org/issues/384.
