### PR TITLE
Products.ZCatalog = 7.2.1 in Plone 6.1

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,12 +1,13 @@
 -c https://zopefoundation.github.io/Zope/releases/5.13/constraints.txt
 packaging==25.0
 pip==25.3
-setuptools==80.9.0
-wheel==0.45.1
+setuptools==80.10.2
+wheel==0.46.3
 zc.buildout==4.1.12
 nt-svcutils==2.13.0
 five.localsitemanager==5.0
 mr.developer==2.0.4
+Products.ZCatalog==7.2.1
 z3c.checkversions==3.0
 z3c.pt==5.1
 zc.recipe.egg==3.0.0

--- a/mx.ini
+++ b/mx.ini
@@ -21,6 +21,7 @@ version-overrides =
     packaging==25.0
     five.localsitemanager==5.0
     mr.developer==2.0.4
+    Products.ZCatalog==7.2.1
     z3c.checkversions==3.0
     z3c.pt==5.1
     zc.recipe.egg==3.0.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -26,6 +26,7 @@ nt-svcutils = 2.13.0
 # You MUST manually keep this in sync with the version-overrides in mx.ini.
 five.localsitemanager = 5.0
 mr.developer = 2.0.4
+Products.ZCatalog = 7.2.1
 z3c.checkversions = 3.0
 z3c.pt = 5.1
 zc.recipe.egg = 3.0.0


### PR DESCRIPTION
Basically, what I'm looking for is this fix:

https://github.com/zopefoundation/Products.ZCatalog/pull/159

Closes plone/Products.CMFPlone#3895