### PR TITLE
Update Plone 6.1 to Zope 5.14.1.

### DIFF
--- a/constraints-extra.txt
+++ b/constraints-extra.txt
@@ -39,8 +39,6 @@ wmctrl==0.5
 z3c.checkversions==3.0
 z3c.dependencychecker==2.15
 zest.pocompile==2.0.0
-zipp==3.23.0
 zodbverify==1.2.1
 zope.mkzeoinstance==6.0
 ZopeUndo==6.0
-tomli==2.4.0; python_version > "3.10"

--- a/constraints-extra.txt
+++ b/constraints-extra.txt
@@ -15,6 +15,7 @@ gitdb==4.0.12
 GitPython==3.1.46
 httplib2==0.31.0
 i18ndude==6.3.0
+importlib-metadata==8.7.1
 incremental==24.11.0
 lockfile==0.12.2
 msgpack==1.1.2
@@ -25,7 +26,6 @@ pep517==0.13.1
 plone.recipe.zeoserver==3.1.0
 plone.releaser==2.5.2
 plone.reload==4.0.0
-plone.versioncheck==1.8.2
 progress==1.6.1
 PyGithub==2.8.1
 PyNaCl==1.6.2
@@ -37,8 +37,11 @@ stdlib-list==0.12.0
 wadllib==2.0.0
 webencodings==0.5.1
 wmctrl==0.5
+z3c.checkversions==3.0
 z3c.dependencychecker==2.15
 zest.pocompile==2.0.0
+zipp==3.23.0
 zodbverify==1.2.1
 zope.mkzeoinstance==6.0
 ZopeUndo==6.0
+tomli==2.4.0; python_version > "3.10"

--- a/constraints-extra.txt
+++ b/constraints-extra.txt
@@ -15,7 +15,6 @@ gitdb==4.0.12
 GitPython==3.1.46
 httplib2==0.31.0
 i18ndude==6.3.0
-importlib-metadata==8.7.1
 incremental==24.11.0
 lockfile==0.12.2
 msgpack==1.1.2

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,11 +1,10 @@
--c https://zopefoundation.github.io/Zope/releases/5.14.1/constraints.txt
-packaging==25.0
-pip==25.3
-setuptools==80.10.2
+-c https://zopefoundation.github.io/Zope/releases/5.14.2/constraints.txt
+packaging==26.0
+pip==26.0.1
+setuptools==81.0.0
 wheel==0.46.3
-zc.buildout==4.1.12
+zc.buildout==4.2.0
 nt-svcutils==2.13.0
-plone.versioncheck==1.8.2
 borg.localrole==4.0.2
 diazo==2.0.5
 five.intid==3.0.2

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,18 +1,11 @@
--c https://zopefoundation.github.io/Zope/releases/5.13/constraints.txt
+-c https://zopefoundation.github.io/Zope/releases/5.14.1/constraints.txt
 packaging==25.0
 pip==25.3
 setuptools==80.10.2
 wheel==0.46.3
 zc.buildout==4.1.12
 nt-svcutils==2.13.0
-five.localsitemanager==5.0
-mr.developer==2.0.4
-Products.ZCatalog==7.2.1
-z3c.checkversions==3.0
-z3c.pt==5.1
-zc.recipe.egg==3.0.0
-zc.recipe.testrunner==3.2
-ZODB==6.0.1
+plone.versioncheck==1.8.2
 borg.localrole==4.0.2
 diazo==2.0.5
 five.intid==3.0.2
@@ -155,14 +148,14 @@ zest.releaser==9.6.2
 zestreleaser.towncrier==1.3.0
 ZODB3==3.11.0
 zodbupdate==2.0
-zope.app.locales==5.0
-zope.componentvocabulary==3.0
-zope.copy==5.0
-zope.intid==5.1
-zope.keyreference==6.1
-zope.pytestlayer==8.3
-zope.ramcache==3.1
-zope.sendmail==6.2
+zope.app.locales==6.0
+zope.componentvocabulary==4.0
+zope.copy==6.0
+zope.intid==6.0
+zope.keyreference==7.0
+zope.pytestlayer==9.1
+zope.ramcache==4.0
+zope.sendmail==7.0
 async-generator==1.10
 attrs==25.3.0
 backports.cached-property==1.0.2
@@ -175,7 +168,6 @@ coverage==7.8.2
 cryptography==45.0.7
 cssselect==1.3.0
 decorator==5.2.1
-exceptiongroup==1.3.0
 feedparser==6.0.12
 furl==2.1.4
 future==1.0.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -174,6 +174,7 @@ future==1.0.0
 gunicorn==23.0.0
 h11==0.16.0
 id==1.5.0
+importlib-metadata==8.7.1
 importlib-resources==6.5.2
 iniconfig==2.1.0
 jaraco.classes==3.4.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -257,4 +257,6 @@ wcwidth==0.2.14
 webresource==1.2
 wrapt==1.17.3
 wsproto==1.2.0
+zipp==3.23.0
+tomli==2.4.0; python_version > "3.10"
 pywin32-ctypes==0.2.3; platform_system == "Windows"

--- a/mx.ini
+++ b/mx.ini
@@ -17,6 +17,4 @@ include =
     mxtests.ini
 version-overrides =
 # You MUST manually keep this in sync with the OVERRIDES in versions.cfg
-# plus the packaging pin above it.
-    packaging==25.0
-    plone.versioncheck==1.8.2
+# plus the packaging-related pins above it, if they differ from Zope.

--- a/mx.ini
+++ b/mx.ini
@@ -19,11 +19,4 @@ version-overrides =
 # You MUST manually keep this in sync with the OVERRIDES in versions.cfg
 # plus the packaging pin above it.
     packaging==25.0
-    five.localsitemanager==5.0
-    mr.developer==2.0.4
-    Products.ZCatalog==7.2.1
-    z3c.checkversions==3.0
-    z3c.pt==5.1
-    zc.recipe.egg==3.0.0
-    zc.recipe.testrunner==3.2
-    ZODB==6.0.1
+    plone.versioncheck==1.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-packaging==25.0
-pip==25.3
-setuptools==80.10.2
+packaging==26.0
+pip==26.0.1
+setuptools==81.0.0
 wheel==0.46.3
-zc.buildout==4.1.12
+zc.buildout==4.2.0
 
 # Windows specific down here (has to be installed here, fails in buildout)
 # Dependency of zope.sendmail:

--- a/sources.cfg
+++ b/sources.cfg
@@ -2,7 +2,7 @@
 # At least, that is the current idea.
 [buildout]
 extends =
-    https://raw.githubusercontent.com/zopefoundation/Zope/master/sources.cfg
+    https://raw.githubusercontent.com/zopefoundation/Zope/5.x/sources.cfg
 
 
 [remotes]

--- a/versions-extra.cfg
+++ b/versions-extra.cfg
@@ -20,6 +20,7 @@ gitdb = 4.0.12
 GitPython = 3.1.46
 httplib2 = 0.31.0
 i18ndude = 6.3.0
+importlib-metadata = 8.7.1
 incremental = 24.11.0
 lockfile = 0.12.2
 msgpack = 1.1.2
@@ -30,7 +31,6 @@ pep517 = 0.13.1
 plone.recipe.zeoserver = 3.1.0
 plone.releaser = 2.5.2
 plone.reload = 4.0.0
-plone.versioncheck = 1.8.2
 progress = 1.6.1
 PyGithub = 2.8.1
 PyNaCl = 1.6.2
@@ -42,13 +42,20 @@ stdlib-list = 0.12.0
 wadllib = 2.0.0
 webencodings = 0.5.1
 wmctrl = 0.5
+z3c.checkversions = 3.0
 z3c.dependencychecker = 2.15
 zest.pocompile = 2.0.0
+zipp = 3.23.0
 zodbverify = 1.2.1
 zope.mkzeoinstance = 6.0
 ZopeUndo = 6.0
+
+[versions:python_version > "3.10"]
+tomli = 2.4.0
 
 [versionannotations]
 # keep this alphabetical please
 smmap =
     Requirement of gitdb<5,>=4.0.1: smmap<6,>=3.0.1
+tomli =
+    Zope 5.14.1 only has a pin for tomli (2.2.1) on Python 3.10

--- a/versions-extra.cfg
+++ b/versions-extra.cfg
@@ -44,17 +44,11 @@ wmctrl = 0.5
 z3c.checkversions = 3.0
 z3c.dependencychecker = 2.15
 zest.pocompile = 2.0.0
-zipp = 3.23.0
 zodbverify = 1.2.1
 zope.mkzeoinstance = 6.0
 ZopeUndo = 6.0
-
-[versions:python_version > "3.10"]
-tomli = 2.4.0
 
 [versionannotations]
 # keep this alphabetical please
 smmap =
     Requirement of gitdb<5,>=4.0.1: smmap<6,>=3.0.1
-tomli =
-    Zope 5.14.1 only has a pin for tomli (2.2.1) on Python 3.10

--- a/versions-extra.cfg
+++ b/versions-extra.cfg
@@ -20,7 +20,6 @@ gitdb = 4.0.12
 GitPython = 3.1.46
 httplib2 = 0.31.0
 i18ndude = 6.3.0
-importlib-metadata = 8.7.1
 incremental = 24.11.0
 lockfile = 0.12.2
 msgpack = 1.1.2

--- a/versions.cfg
+++ b/versions.cfg
@@ -7,7 +7,7 @@
 # Based on latest development Zope:
 # extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
 # Based on released Zope:
-extends = https://zopefoundation.github.io/Zope/releases/5.13/versions.cfg
+extends = https://zopefoundation.github.io/Zope/releases/5.14.1/versions.cfg
 
 
 [versions]
@@ -24,14 +24,7 @@ nt-svcutils = 2.13.0
 
 # OVERRIDES
 # You MUST manually keep this in sync with the version-overrides in mx.ini.
-five.localsitemanager = 5.0
-mr.developer = 2.0.4
-Products.ZCatalog = 7.2.1
-z3c.checkversions = 3.0
-z3c.pt = 5.1
-zc.recipe.egg = 3.0.0
-zc.recipe.testrunner = 3.2
-ZODB = 6.0.1
+plone.versioncheck = 1.8.2
 
 # CORE PLONE.
 # These packages are what you get when installing Plone plus test dependencies,
@@ -187,14 +180,14 @@ zest.releaser = 9.6.2
 zestreleaser.towncrier = 1.3.0
 ZODB3 = 3.11.0
 zodbupdate = 2.0
-zope.app.locales = 5.0
-zope.componentvocabulary = 3.0
-zope.copy = 5.0
-zope.intid = 5.1
-zope.keyreference = 6.1
-zope.pytestlayer = 8.3
-zope.ramcache = 3.1
-zope.sendmail = 6.2
+zope.app.locales = 6.0
+zope.componentvocabulary = 4.0
+zope.copy = 6.0
+zope.intid = 6.0
+zope.keyreference = 7.0
+zope.pytestlayer = 9.1
+zope.ramcache = 4.0
+zope.sendmail = 7.0
 
 # CORE DEPENDENCIES: other
 # These packages are what you get when installing Plone and its tests,
@@ -211,7 +204,6 @@ coverage = 7.8.2
 cryptography = 45.0.7
 cssselect = 1.3.0
 decorator = 5.2.1
-exceptiongroup = 1.3.0
 feedparser = 6.0.12
 furl = 2.1.4
 future = 1.0.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -210,6 +210,7 @@ future = 1.0.0
 gunicorn = 23.0.0
 h11 = 0.16.0
 id = 1.5.0
+importlib-metadata = 8.7.1
 importlib-resources = 6.5.2
 iniconfig = 2.1.0
 jaraco.classes = 3.4.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -294,6 +294,10 @@ wcwidth = 0.2.14
 webresource = 1.2
 wrapt = 1.17.3
 wsproto = 1.2.0
+zipp = 3.23.0
+
+[versions:python_version > "3.10"]
+tomli = 2.4.0
 
 [versions:windows]
 pywin32-ctypes = 0.2.3
@@ -310,3 +314,5 @@ protobuf =
    This has an exact version pin in the robotframework-browser package.
 selenium =
     robotframework-seleniumlibrary 6.1.0 is incompatible with 4.10.0. See https://github.com/robotframework/SeleniumLibrary/issues/1835
+tomli =
+    Zope 5.14.1 only has a pin for tomli (2.2.1) on Python 3.10

--- a/versions.cfg
+++ b/versions.cfg
@@ -7,24 +7,23 @@
 # Based on latest development Zope:
 # extends = https://raw.githubusercontent.com/zopefoundation/Zope/master/versions.cfg
 # Based on released Zope:
-extends = https://zopefoundation.github.io/Zope/releases/5.14.1/versions.cfg
+extends = https://zopefoundation.github.io/Zope/releases/5.14.2/versions.cfg
 
 
 [versions]
 # Basics
 # !! keep in sync with requirements.txt !!
-packaging = 25.0
-pip = 25.3
-setuptools = 80.10.2
+packaging = 26.0
+pip = 26.0.1
+setuptools = 81.0.0
 wheel = 0.46.3
-zc.buildout = 4.1.12
+zc.buildout = 4.2.0
 
 # windows specific
 nt-svcutils = 2.13.0
 
 # OVERRIDES
 # You MUST manually keep this in sync with the version-overrides in mx.ini.
-plone.versioncheck = 1.8.2
 
 # CORE PLONE.
 # These packages are what you get when installing Plone plus test dependencies,


### PR DESCRIPTION
Note that all `zope.*` packages that are pinned by Zope now use native namespaces. So we had to do the same for the few `zope.*` pins that we have ourselves.

Note though that in our `versions-extra.cfg` we have `zope.mkzeoinstance = 6.0` which still uses the old-style `pkg_resources` namespace. But the repo is archived, and the package is only used by `plone.recipe.zeoserver`.  So should be okay.

Actually, no it is NOT okay.  If I add a zeoserver part in `buildout.coredev` I get an error when running buildout:

```
Installing zeoserver.
While:
  Installing zeoserver.

An internal error occurred due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/Users/maurits/community/plone-coredev/6.1/lib/python3.13/site-packages/zc/buildout/buildout.py", line 2330, in main
    getattr(buildout, command)(args)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/maurits/community/plone-coredev/6.1/lib/python3.13/site-packages/zc/buildout/buildout.py", line 869, in install
    installed_files = self[part]._call(recipe.install)
  File "/Users/maurits/community/plone-coredev/6.1/lib/python3.13/site-packages/zc/buildout/buildout.py", line 1689, in _call
    return f()
  File "/Users/maurits/shared-eggs/cp313/plone.recipe.zeoserver-3.0.5-py3.13.egg/plone/recipe/zeoserver/recipe.py", line 86, in install
    from zope.mkzeoinstance import ZEOInstanceBuilder
  File "/Users/maurits/shared-eggs/cp313/zope.mkzeoinstance-6.0-py3.13.egg/zope/mkzeoinstance/__init__.py", line 46, in <module>
    import ZODB
  File "/Users/maurits/shared-eggs/cp313/ZODB-6.2-py3.13.egg/ZODB/__init__.py", line 17, in <module>
    from persistent import TimeStamp
  File "/Users/maurits/shared-eggs/cp313/persistent-6.5-py3.13-macosx-15.4-arm64.egg/persistent/__init__.py", line 34, in <module>
    from persistent import interfaces as _interfaces
  File "/Users/maurits/shared-eggs/cp313/persistent-6.5-py3.13-macosx-15.4-arm64.egg/persistent/interfaces.py", line 17, in <module>
    from zope.interface import Attribute
ModuleNotFoundError: No module named 'zope.interface'
```

So at the moment we cannot use this new Zope version.  So I open this as a draft PR.

Possible solutions I see:

1. Ask to unarchive the `zope.mkzeoinstance` repo and switch it to using native namespaces.
2. Copy the relevant part of `zope.mkzeoinstance` to `plone.recipe.zeoserver`.  This should be done on branches for both 6.1 and 6.2.

Why did I not notice this on Plone 6.2?  Ah, because there we are using `zc.buildout` 5, which basically installs every package as if it had native namespaces.

