### PR TITLE
6.1: Upgrade to latest pip 26.1.2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 packaging==26.2
-pip==26.1.1
+pip==26.1.2
 setuptools==81.0.0
 wheel==0.47.0
 zc.buildout==4.2.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -14,7 +14,7 @@ extends = https://zopefoundation.github.io/Zope/releases/5.14.2/versions.cfg
 # Basics
 # !! keep in sync with requirements.txt !!
 packaging = 26.2
-pip = 26.1.1
+pip = 26.1.2
 setuptools = 81.0.0
 wheel = 0.47.0
 zc.buildout = 4.2.0


### PR DESCRIPTION
https://pip.pypa.io/en/stable/news/
