### PR TITLE
6.2: Upgrade to latest pip 26.1.2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 horse-with-no-namespace==20260202.0
-pip==26.1.1
+pip==26.1.2
 setuptools==81.0.0
 wheel==0.47.0
 zc.buildout==5.2.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -14,7 +14,7 @@ extends = https://zopefoundation.github.io/Zope/releases/6.1/versions.cfg
 # Basics
 # !! keep in sync with requirements.txt !!
 horse-with-no-namespace = 20260202.0
-pip = 26.1.1
+pip = 26.1.2
 setuptools = 81.0.0
 wheel = 0.47.0
 zc.buildout = 5.2.0


### PR DESCRIPTION
https://pip.pypa.io/en/stable/news/

